### PR TITLE
Fix: Full Consistency Sweep for Examples and Templates

### DIFF
--- a/examples/demo-app-sandbox-intermediate/docker-compose.yml
+++ b/examples/demo-app-sandbox-intermediate/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     environment:
       - DATABASE_URL=${DATABASE_URL:-postgresql://${POSTGRES_USER:-sandbox_user}:${POSTGRES_PASSWORD:-devpassword}@postgres:5432/${POSTGRES_DB:-sandbox_dev}}
       - REDIS_URL=redis://redis:6379
-      - RABBITMQ_URL=amqp://guest:guest@rabbitmq:5672/
+      - RABBITMQ_URL=${RABBITMQ_URL:-amqp://${RABBITMQ_USER:-guest}:${RABBITMQ_PASS:-guest}@rabbitmq:5672/}
       - FIREWALL_MODE=permissive
     cap_add:
       - NET_ADMIN
@@ -58,8 +58,8 @@ services:
   rabbitmq:
     image: rabbitmq:3-management-alpine
     environment:
-      RABBITMQ_DEFAULT_USER: guest
-      RABBITMQ_DEFAULT_PASS: guest
+      RABBITMQ_DEFAULT_USER: ${RABBITMQ_USER:-guest}
+      RABBITMQ_DEFAULT_PASS: ${RABBITMQ_PASS:-guest}
     healthcheck:
       test: ["CMD", "rabbitmq-diagnostics", "ping"]
       interval: 10s

--- a/examples/demo-app-sandbox-yolo/docker-compose.yml
+++ b/examples/demo-app-sandbox-yolo/docker-compose.yml
@@ -34,7 +34,7 @@ services:
 
     environment:
       # Database Configuration
-      - DATABASE_URL=postgresql://${POSTGRES_USER:-sandbox_user}:${POSTGRES_PASSWORD:-devpassword}@postgres:5432/${POSTGRES_DB:-sandbox_dev}
+      - DATABASE_URL=${DATABASE_URL:-postgresql://${POSTGRES_USER:-sandbox_user}:${POSTGRES_PASSWORD:-devpassword}@postgres:5432/${POSTGRES_DB:-sandbox_dev}}
       - DATABASE_POOL_SIZE=${DATABASE_POOL_SIZE:-10}
       - DATABASE_MAX_OVERFLOW=${DATABASE_MAX_OVERFLOW:-20}
 

--- a/templates/legacy/base/docker-compose.base.yml
+++ b/templates/legacy/base/docker-compose.base.yml
@@ -6,7 +6,7 @@ services:
   #   environment:
   #     POSTGRES_DB: {{DB_NAME}}
   #     POSTGRES_USER: {{DB_USER}}
-  #     POSTGRES_PASSWORD: devpassword
+  #     POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-devpassword}
   #   ports:
   #     - "5432:5432"
   #   volumes:
@@ -24,8 +24,8 @@ services:
   #   environment:
   #     MYSQL_DATABASE: {{DB_NAME}}
   #     MYSQL_USER: {{DB_USER}}
-  #     MYSQL_PASSWORD: devpassword
-  #     MYSQL_ROOT_PASSWORD: rootpassword
+  #     MYSQL_PASSWORD: ${MYSQL_PASSWORD:-devpassword}
+  #     MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-rootpassword}
   #   ports:
   #     - "3306:3306"
   #   volumes:
@@ -36,8 +36,8 @@ services:
   #   image: mongo:7
   #   container_name: {{PROJECT_NAME}}-mongodb
   #   environment:
-  #     MONGO_INITDB_ROOT_USERNAME: admin
-  #     MONGO_INITDB_ROOT_PASSWORD: devpassword
+  #     MONGO_INITDB_ROOT_USERNAME: ${MONGO_INITDB_ROOT_USERNAME:-admin}
+  #     MONGO_INITDB_ROOT_PASSWORD: ${MONGO_INITDB_ROOT_PASSWORD:-devpassword}
   #   ports:
   #     - "27017:27017"
   #   volumes:

--- a/templates/legacy/node/EXAMPLE.md
+++ b/templates/legacy/node/EXAMPLE.md
@@ -88,6 +88,7 @@ my-node-project/
     "FIREWALL_MODE": "strict",
     "NODE_ENV": "development",
     "MONGODB_URL": "mongodb://admin:devpass@mongodb:27017/myapp?authSource=admin",
+    "// NOTE": "For passwords with special characters, URL-encode them: encodeURIComponent(password)",
     "REDIS_URL": "redis://redis:6379",
     "PORT": "3000"
   }
@@ -376,6 +377,9 @@ start();
 import { MongoClient, Db } from 'mongodb';
 import { createClient, RedisClientType } from 'redis';
 
+// NOTE: For passwords with special characters (@, :, /, etc.), URL-encode them:
+// const password = encodeURIComponent(process.env.MONGO_PASSWORD || 'devpass');
+// const MONGODB_URL = `mongodb://admin:${password}@mongodb:27017/myapp?authSource=admin`;
 const MONGODB_URL = process.env.MONGODB_URL || 'mongodb://admin:devpass@mongodb:27017/myapp?authSource=admin';
 const REDIS_URL = process.env.REDIS_URL || 'redis://redis:6379';
 

--- a/templates/legacy/python/EXAMPLE.md
+++ b/templates/legacy/python/EXAMPLE.md
@@ -327,6 +327,9 @@ from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession, async_sess
 from sqlalchemy.orm import declarative_base
 import os
 
+# NOTE: For passwords with special characters (@, :, /, etc.), use urllib.parse.quote()
+# from urllib.parse import quote
+# DATABASE_URL = f"postgresql+asyncpg://{quote(user, safe='')}:{quote(password, safe='')}@host:port/db"
 DATABASE_URL = os.getenv("DATABASE_URL", "postgresql+asyncpg://myapp:devpass@postgres:5432/myapp_db")
 
 engine = create_async_engine(DATABASE_URL, echo=True)

--- a/templates/mcp/mcp.advanced.json
+++ b/templates/mcp/mcp.advanced.json
@@ -50,7 +50,7 @@
     },
     "postgresConnectionString": {
       "type": "promptString",
-      "description": "PostgreSQL connection string",
+      "description": "PostgreSQL connection string. URL-encode special characters in passwords.",
       "default": "postgresql://user:password@localhost:5432/db"
     },
     "braveApiKey": {

--- a/templates/mcp/mcp.yolo.json
+++ b/templates/mcp/mcp.yolo.json
@@ -66,7 +66,7 @@
     },
     "postgresConnectionString": {
       "type": "promptString",
-      "description": "PostgreSQL connection string",
+      "description": "PostgreSQL connection string. URL-encode special characters in passwords.",
       "default": "postgresql://user:password@localhost:5432/db"
     },
     "braveApiKey": {

--- a/templates/variables/variables.advanced.json
+++ b/templates/variables/variables.advanced.json
@@ -51,6 +51,7 @@
     }
   },
   "derived_vars": {
+    "_note": "URLs constructed from components. Application code handles URL encoding for special characters in credentials.",
     "DATABASE_URL": "postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}"
   },
   "vs_code_inputs": {

--- a/templates/variables/variables.basic.json
+++ b/templates/variables/variables.basic.json
@@ -20,6 +20,7 @@
     "REDIS_PORT": "6379"
   },
   "derived_vars": {
+    "_note": "URLs constructed from components. Application code handles URL encoding for special characters in credentials.",
     "DATABASE_URL": "postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}"
   },
   "notes": [

--- a/templates/variables/variables.intermediate.json
+++ b/templates/variables/variables.intermediate.json
@@ -29,6 +29,7 @@
     "RABBITMQ_MANAGEMENT_PORT": "15672"
   },
   "derived_vars": {
+    "_note": "URLs constructed from components. Application code handles URL encoding for special characters in credentials.",
     "DATABASE_URL": "postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}"
   },
   "vs_code_inputs": {

--- a/templates/variables/variables.yolo.json
+++ b/templates/variables/variables.yolo.json
@@ -104,6 +104,7 @@
     }
   },
   "derived_vars": {
+    "_note": "URLs constructed from components. Application code handles URL encoding for special characters in credentials.",
     "DATABASE_URL": "postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}",
     "MONGODB_URI": "mongodb://${MONGO_INITDB_ROOT_USERNAME}:${MONGO_INITDB_ROOT_PASSWORD}@${MONGO_HOST}:${MONGO_PORT}/${MONGO_INITDB_DATABASE}",
     "REDIS_URL": "redis://${REDIS_HOST}:${REDIS_PORT}/${REDIS_DB}",


### PR DESCRIPTION
## Summary

Comprehensive consistency sweep addressing remaining inconsistencies discovered after PRs #25, #26, and #27.

---

## Changes Made

### 1. Docker Compose Files (2 files)

**examples/demo-app-sandbox-yolo/docker-compose.yml**
- Added `${DATABASE_URL:-...}` wrapper to allow full DATABASE_URL override
- Before: Could not override entire connection string
- After: Consistent with other modes

**examples/demo-app-sandbox-intermediate/docker-compose.yml**
- Fixed hardcoded RabbitMQ credentials (`guest:guest`)
- Now uses `${RABBITMQ_USER:-guest}` and `${RABBITMQ_PASS:-guest}` pattern
- Consistent with all other credential patterns in the repository

### 2. Variables JSON Templates (4 files)

Added `_note` field to `derived_vars` section in:
- `templates/variables/variables.basic.json`
- `templates/variables/variables.intermediate.json`
- `templates/variables/variables.advanced.json`
- `templates/variables/variables.yolo.json`

Note explains that application code handles URL encoding for special characters in credentials.

### 3. Legacy Templates (3 files)

**templates/legacy/base/docker-compose.base.yml**
- Updated commented examples to use `${VAR:-default}` pattern
- PostgreSQL, MySQL, MongoDB credentials now consistent

**templates/legacy/python/EXAMPLE.md**
- Added URL encoding note to DATABASE_URL example (line 330)
- Shows how to use `urllib.parse.quote()` for passwords with special characters

**templates/legacy/node/EXAMPLE.md**
- Added URL encoding notes to MongoDB URL examples (lines 90, 380)
- Shows how to use `encodeURIComponent()` for passwords with special characters

### 4. MCP Configuration Files (2 files)

**templates/mcp/mcp.advanced.json & mcp.yolo.json**
- Updated `postgresConnectionString` description
- Added note: "URL-encode special characters in passwords"

---

## Files Changed

| Category | Count | Files |
|----------|-------|-------|
| Docker Compose | 2 | YOLO, Intermediate |
| Variables JSON | 4 | basic, intermediate, advanced, yolo |
| Legacy Templates | 3 | docker-compose.base.yml, python/EXAMPLE.md, node/EXAMPLE.md |
| MCP Configs | 2 | mcp.advanced.json, mcp.yolo.json |
| **Total** | **11** | |

---

## Why These Changes Matter

1. **Consistency**: All templates now follow the same `${VAR:-default}` pattern
2. **Documentation**: Users are warned about URL encoding requirements
3. **Flexibility**: YOLO mode can now override DATABASE_URL like other modes
4. **Security**: Proper patterns prevent hardcoded credentials

---

## Related Issues/PRs

- Follow-up to: #25, #26, #27 (Issue #24 fixes)
- Discovered by: Comprehensive repository scan after security review

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)