### PR TITLE
feat: rename plugin from 'sandbox-maxxing' to 'sandboxxer' (v2.2.2) (…

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,9 +7,9 @@
   },
   "plugins": [
     {
-      "name": "sandbox-maxxing",
+      "name": "sandboxxer",
       "description": "Interactive assistant for setting up, troubleshooting, and securing Claude Code Docker sandbox environments with four-mode system (Basic, Intermediate, Advanced, YOLO)",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "source": "./",
       "author": {
         "name": "Andrew C. Choi"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
-  "name": "sandbox-maxxing",
-  "version": "2.2.1",
+  "name": "sandboxxer",
+  "version": "2.2.2",
   "description": "Interactive assistant for setting up, troubleshooting, and securing Claude Code Docker sandbox environments with four-mode system (Basic, Intermediate, Advanced, YOLO)",
   "author": {
     "name": "shadow developer"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.2.2] - 2025-12-18
+
+### Changed
+- **Plugin name**: Renamed from "sandbox-maxxing" to "sandboxxer"
+  - Updated plugin.json and marketplace.json with new plugin name
+  - Repository and marketplace name remain "sandbox-maxxing"
+  - Updated documentation to clarify naming convention
+  - Commands and skills continue to use "sandbox" shorthand
+
 ## [2.2.1] - 2025-12-16
 
 ### Fixed
@@ -46,7 +55,7 @@ All notable changes to this project will be documented in this file.
   - Updated skill references to show correct directory structure
 - **Terminology inconsistencies** (4 occurrences):
   - Fixed "tier" → "mode" in templates/legacy/README.md (3 occurrences)
-  - Standardized plugin naming: "sandbox-maxxing" (official) vs "sandbox" (shorthand)
+  - Standardized plugin naming: "sandboxxer" (plugin name), "sandbox-maxxing" (repository/marketplace), "sandbox" (shorthand)
 
 ### Changed
 - **Documentation completeness**: Improved from 91% to 100%

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -319,7 +319,7 @@ lsof -i :6379
 
 ```bash
 # Reinstall plugin
-claude plugins remove sandbox-maxxing
+claude plugins remove sandboxxer
 claude plugins add .
 
 # Verify installation

--- a/README.md
+++ b/README.md
@@ -394,13 +394,15 @@ This plugin uses consistent naming across different contexts:
 
 | Context | Name | Example |
 |---------|------|---------|
+| Plugin name | sandboxxer | Plugin installation and management |
 | GitHub repository | sandbox-maxxing | github.com/andrewcchoi/sandbox-maxxing |
 | Slash commands | /sandbox:* | /sandbox:basic, /sandbox:yolo |
 | Skills | sandbox-* | sandbox-setup-basic |
 | User-facing title | Claude Code Sandbox Plugin | In documentation headers |
 
 **Why different names?**
-- **sandbox-maxxing**: Official repository name (reflects Windows WSL 2 compatibility)
+- **sandboxxer**: Official plugin name used for installation and management
+- **sandbox-maxxing**: Repository and marketplace name (reflects Windows WSL 2 compatibility)
 - **sandbox**: Shorthand used in commands and skills for brevity
 - **Claude Code Sandbox Plugin**: Full descriptive name for user-facing documentation
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -85,7 +85,7 @@ Choose the appropriate security mode for your use case:
 - **Advanced Mode**: Use for production-like environments and sensitive work
 - **YOLO Mode**: Use only if you understand the security implications
 
-See [docs/security-model.md](docs/security-model.md) for detailed security model documentation.
+See [docs/features/security-model.md](docs/features/security-model.md) for detailed security model documentation.
 
 ### 2. Firewall Configuration
 
@@ -102,7 +102,7 @@ See [docs/security-model.md](docs/security-model.md) for detailed security model
 - Use build secrets for private registry authentication
 - Read-only mount cloud CLI credentials when possible
 
-See [docs/SECRETS.md](docs/SECRETS.md) for comprehensive secrets management guide.
+See [docs/features/SECRETS.md](docs/features/SECRETS.md) for comprehensive secrets management guide.
 
 ### 4. Container Security
 
@@ -155,7 +155,7 @@ See [docs/SECRETS.md](docs/SECRETS.md) for comprehensive secrets management guid
 
 ### Threat Model
 
-See [docs/security-model.md](docs/security-model.md) for comprehensive threat model documentation.
+See [docs/features/security-model.md](docs/features/security-model.md) for comprehensive threat model documentation.
 
 ## Scope
 
@@ -219,7 +219,7 @@ We'll recognize security researchers who responsibly disclose vulnerabilities:
 
 For security-related questions that are not vulnerabilities:
 
-1. Check [docs/security-model.md](docs/security-model.md) for security architecture
+1. Check [docs/features/security-model.md](docs/features/security-model.md) for security architecture
 2. Use [GitHub Discussions](https://github.com/andrewcchoi/sandbox-maxxing/discussions) for public questions
 3. Open a regular GitHub issue for feature requests
 

--- a/commands/README.md
+++ b/commands/README.md
@@ -80,7 +80,7 @@ Each command loads and executes the corresponding skill with user-friendly promp
 - Network errors
 - Any sandbox-related problem
 
-See also: [Troubleshooting Guide](../docs/TROUBLESHOOTING.md)
+See also: [Troubleshooting Guide](../docs/features/TROUBLESHOOTING.md)
 
 ---
 
@@ -107,7 +107,7 @@ See also: [Troubleshooting Guide](../docs/TROUBLESHOOTING.md)
 - Learning security best practices
 - Hardening sandbox environment
 
-See also: [Security Model](../docs/security-model.md)
+See also: [Security Model](../docs/features/security-model.md)
 
 ---
 
@@ -335,13 +335,13 @@ Test commands with:
 
 ### Core Documentation
 - [Skills README](../skills/README.md) - Skill details and workflows
-- [Modes Guide](../docs/MODES.md) - Mode comparison and selection
-- [Troubleshooting](../docs/TROUBLESHOOTING.md) - Common issues
+- [Modes Guide](../docs/features/MODES.md) - Mode comparison and selection
+- [Troubleshooting](../docs/features/TROUBLESHOOTING.md) - Common issues
 
 ### Configuration
 - [DevContainer Setup](../DEVELOPMENT.md) - DevContainer configuration
-- [Variables Guide](../docs/VARIABLES.md) - Environment configuration
-- [Secrets Management](../docs/SECRETS.md) - Credential handling
+- [Variables Guide](../docs/features/VARIABLES.md) - Environment configuration
+- [Secrets Management](../docs/features/SECRETS.md) - Credential handling
 
 ### Examples
 - [Examples README](../examples/README.md) - Example projects

--- a/skills/README.md
+++ b/skills/README.md
@@ -129,7 +129,7 @@ Skills are invoked through slash commands in Claude Code. When you use a command
 
 **Location:** `skills/sandbox-troubleshoot/SKILL.md`
 
-See also: [Troubleshooting Guide](../docs/TROUBLESHOOTING.md)
+See also: [Troubleshooting Guide](../docs/features/TROUBLESHOOTING.md)
 
 ---
 
@@ -159,7 +159,7 @@ See also: [Troubleshooting Guide](../docs/TROUBLESHOOTING.md)
 
 **Location:** `skills/sandbox-security/SKILL.md`
 
-See also: [Security Model](../docs/security-model.md)
+See also: [Security Model](../docs/features/security-model.md)
 
 ---
 
@@ -318,14 +318,14 @@ Test skills with various scenarios:
 ## Related Documentation
 
 ### Core Documentation
-- [Modes Comparison](../docs/MODES.md) - Detailed mode comparison
-- [Security Model](../docs/security-model.md) - Security architecture
-- [Troubleshooting Guide](../docs/TROUBLESHOOTING.md) - Common issues and fixes
+- [Modes Comparison](../docs/features/MODES.md) - Detailed mode comparison
+- [Security Model](../docs/features/security-model.md) - Security architecture
+- [Troubleshooting Guide](../docs/features/TROUBLESHOOTING.md) - Common issues and fixes
 
 ### Configuration Guides
-- [Variables Guide](../docs/VARIABLES.md) - Environment variables and build args
-- [Secrets Management](../docs/SECRETS.md) - Credential handling
-- [MCP Configuration](../docs/MCP.md) - MCP server setup
+- [Variables Guide](../docs/features/VARIABLES.md) - Environment variables and build args
+- [Secrets Management](../docs/features/SECRETS.md) - Credential handling
+- [MCP Configuration](../docs/features/MCP.md) - MCP server setup
 
 ### Reference
 - [Development Guide](../DEVELOPMENT.md) - Plugin development

--- a/skills/sandbox-setup-advanced/references/customization.md
+++ b/skills/sandbox-setup-advanced/references/customization.md
@@ -594,7 +594,7 @@ And update firewall for AI provider APIs.
 
 - Review [security.md](security.md) to understand the security model
 - Check [troubleshooting.md](troubleshooting.md) for common issues
-- Browse [examples/](../../../../examples/) for complete configuration examples
+- Browse [examples/](../../../examples/) for complete configuration examples
 
 ---
 

--- a/skills/sandbox-setup-advanced/references/troubleshooting.md
+++ b/skills/sandbox-setup-advanced/references/troubleshooting.md
@@ -614,7 +614,7 @@ docker compose up -d
 
 ## Still having issues?
 
-1. Check the [examples](../../../../examples/) for working configurations
+1. Check the [examples](../../../examples/) for working configurations
 2. Review [customization.md](customization.md) for configuration tips
 3. Check [security.md](security.md) for firewall behavior
 4. Search existing GitHub issues

--- a/templates/README.md
+++ b/templates/README.md
@@ -191,7 +191,7 @@ iptables -P OUTPUT DROP
 # - strict: Whitelist-based (comprehensive categories)
 ```
 
-See [Security Model](../docs/security-model.md) for detailed firewall documentation.
+See [Security Model](../docs/features/security-model.md) for detailed firewall documentation.
 
 ### 4. Docker Compose Templates (`compose/`)
 
@@ -241,7 +241,7 @@ VS Code extension lists for each sandbox mode.
 - **Productivity:** TODO Tree, Error Lens, Code Spell Checker
 - **Fun:** Power Mode, Rainbow Brackets, Pets
 
-See [Extensions Reference](../docs/EXTENSIONS.md) for full lists.
+See [Extensions Reference](../docs/features/EXTENSIONS.md) for full lists.
 
 ### 6. MCP Server Templates (`mcp/`)
 
@@ -267,7 +267,7 @@ MCP (Model Context Protocol) server configurations for each mode.
 - **slack** - Slack integration
 - **google-drive** - Google Drive access
 
-See [MCP Configuration Guide](../docs/MCP.md) for details.
+See [MCP Configuration Guide](../docs/features/MCP.md) for details.
 
 ### 7. Variable Templates (`variables/`)
 
@@ -295,7 +295,7 @@ Environment variable and build argument configurations for each mode.
 | Advanced | 12+ | 20+ | Comprehensive configuration |
 | YOLO | Custom | Custom | User-defined |
 
-See [Variables Guide](../docs/VARIABLES.md) for detailed documentation.
+See [Variables Guide](../docs/features/VARIABLES.md) for detailed documentation.
 
 ## Master Templates
 
@@ -686,15 +686,15 @@ All fixes are included by default when using templates since version 2.2.1.
 ## Related Documentation
 
 ### Configuration Guides
-- [Modes Guide](../docs/MODES.md) - Mode comparison and selection
-- [Variables Guide](../docs/VARIABLES.md) - Environment variables and build args
-- [Secrets Management](../docs/SECRETS.md) - Credential handling
-- [MCP Configuration](../docs/MCP.md) - MCP server setup
-- [Extensions Reference](../docs/EXTENSIONS.md) - VS Code extensions
+- [Modes Guide](../docs/features/MODES.md) - Mode comparison and selection
+- [Variables Guide](../docs/features/VARIABLES.md) - Environment variables and build args
+- [Secrets Management](../docs/features/SECRETS.md) - Credential handling
+- [MCP Configuration](../docs/features/MCP.md) - MCP server setup
+- [Extensions Reference](../docs/features/EXTENSIONS.md) - VS Code extensions
 
 ### Security
-- [Security Model](../docs/security-model.md) - Security architecture
-- [Firewall Documentation](../docs/security-model.md#network-isolation--firewall-modes) - Firewall modes
+- [Security Model](../docs/features/security-model.md) - Security architecture
+- [Firewall Documentation](../docs/features/security-model.md#network-isolation--firewall-modes) - Firewall modes
 
 ### Skills and Commands
 - [Skills README](../skills/README.md) - Setup skills that use templates

--- a/templates/legacy/README.md
+++ b/templates/legacy/README.md
@@ -58,7 +58,7 @@ They may be removed in a future major version (3.0+).
 
 See:
 - [ARCHITECTURE.md](../../docs/ARCHITECTURE.md) - New template system
-- [MODES.md](../../docs/MODES.md) - Four-mode comparison
+- [MODES.md](../../docs/features/MODES.md) - Four-mode comparison
 - [CHANGELOG.md](../../CHANGELOG.md) - Version history
 
 ---


### PR DESCRIPTION
…#39)

## Changes

### Plugin Configuration
- Updated plugin name to 'sandboxxer' in plugin.json and marketplace.json
- Marketplace name remains 'sandbox-maxxing' as requested
- Bumped version to 2.2.2

### Documentation Updates
- Updated README.md naming convention table to clarify plugin vs repository names
- Updated CHANGELOG.md with v2.2.2 release notes
- Updated DEVELOPMENT.md plugin removal command reference
- Updated all documentation to reflect new plugin name

### Link Fixes (Repo Keeper)
- Fixed 20+ broken documentation links pointing to docs/ instead of docs/features/
- Updated links in: commands/README.md, skills/README.md, SECURITY.md, templates/README.md, templates/legacy/README.md
- Fixed incorrect relative paths in skills/sandbox-setup-advanced/references/ (../../../../examples/ -> ../../../examples/)

## Summary
- Plugin name: 'sandboxxer' (new, with 2 x's)
- Repository name: 'sandbox-maxxing' (unchanged)
- Marketplace name: 'sandbox-maxxing' (unchanged)
- Commands: '/sandbox:*' (unchanged)
- Skills: 'sandbox-*' (unchanged)

Files changed: 12
- Plugin config: 2 files
- Core docs: 3 files
- Documentation links: 7 files