### PR TITLE
feat(proxy): add proxy-friendly Dockerfile architecture

### DIFF
--- a/skills/devcontainer-setup-advanced/SKILL.md
+++ b/skills/devcontainer-setup-advanced/SKILL.md
@@ -29,9 +29,10 @@ Then:
 1. Project name (e.g., "demo-app")
 2. Additional languages (e.g., "none", "go", "rust", or comma-separated)
 3. Services needed (e.g., "postgres", "redis", or comma-separated)
-4. Firewall mode (e.g., "permissive", "strict")
-5. Firewall ports to allow (e.g., "443,8080" or "80,443,8000")
-6. Confirmation (e.g., "yes", "y")
+4. Proxy-friendly mode (e.g., "yes", "no")
+5. Firewall mode (e.g., "permissive", "strict")
+6. Firewall ports to allow (e.g., "443,8080" or "80,443,8000")
+7. Confirmation (e.g., "yes", "y")
 
 **Example automated invocation:**
 ```
@@ -182,17 +183,35 @@ echo "Auto-detected languages: ${DETECTED_LANGUAGES[*]:-none}"
 
 ### Step 2B: Ask User Questions
 
-**Question 1: Firewall Mode**
+**Question 1: Proxy-Friendly Mode**
 ```
 Use AskUserQuestion tool:
 
+Question: "Are you behind a corporate proxy?"
+Options:
+- No: Install all dev tools and shell extras (default)
+- Yes: Minimal build - skip GitHub downloads (git-delta, zsh plugins, dev tools)
+```
+
+If "Yes", configure build args in docker-compose.yml:
+```yaml
+services:
+  app:
+    build:
+      args:
+        INSTALL_SHELL_EXTRAS: "false"
+        INSTALL_DEV_TOOLS: "false"
+```
+
+**Question 2: Firewall Mode**
+```
 Question: "Select firewall mode:"
 Options:
 - Permissive: Allow all outbound traffic (development convenience)
 - Strict: Only allow domains in allowlist (security-focused) [Recommended]
 ```
 
-**Question 2: Additional Languages**
+**Question 3: Additional Languages**
 ```
 Question: "Additional languages to include?"
 Options:

--- a/skills/devcontainer-setup-advanced/templates/partial-cpp-clang.dockerfile
+++ b/skills/devcontainer-setup-advanced/templates/partial-cpp-clang.dockerfile
@@ -1,26 +1,47 @@
 # === C++ (CLANG) LANGUAGE ADDITIONS ===
+# Uses LLVM's official apt repository for latest Clang (proxy-friendly via apt)
+# ============================================================================
+
 USER root
 
-# Install Clang toolchain and build tools
+# Add LLVM apt repository for latest Clang toolchain
+# The GPG key download is one-time during build
+RUN wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /usr/share/keyrings/llvm.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/llvm.gpg] http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-17 main" \
+    > /etc/apt/sources.list.d/llvm.list
+
+# Install Clang 17 toolchain and build tools (via apt - proxy-friendly)
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    clang \
-    clang-format \
-    clang-tidy \
-    lldb \
+    clang-17 \
+    clang-format-17 \
+    clang-tidy-17 \
+    lldb-17 \
+    lld-17 \
     cmake \
     ninja-build \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Install vcpkg (C++ package manager)
-RUN git clone https://github.com/microsoft/vcpkg.git /opt/vcpkg && \
-    /opt/vcpkg/bootstrap-vcpkg.sh && \
-    ln -s /opt/vcpkg/vcpkg /usr/local/bin/vcpkg && \
-    chown -R node:node /opt/vcpkg
+# Create version-agnostic symlinks
+RUN ln -sf /usr/bin/clang-17 /usr/bin/clang && \
+    ln -sf /usr/bin/clang++-17 /usr/bin/clang++ && \
+    ln -sf /usr/bin/clang-format-17 /usr/bin/clang-format && \
+    ln -sf /usr/bin/clang-tidy-17 /usr/bin/clang-tidy && \
+    ln -sf /usr/bin/lldb-17 /usr/bin/lldb
 
 # Set C++ environment variables for Clang
 ENV CXX=clang++ \
-    CC=clang \
-    VCPKG_ROOT=/opt/vcpkg
+    CC=clang
+
+# vcpkg installation - conditional on INSTALL_DEV_TOOLS
+# Requires network access to github.com
+ARG INSTALL_CPP_TOOLS=${INSTALL_DEV_TOOLS:-true}
+RUN if [ "$INSTALL_CPP_TOOLS" = "true" ]; then \
+    git clone https://github.com/microsoft/vcpkg.git /opt/vcpkg && \
+    /opt/vcpkg/bootstrap-vcpkg.sh && \
+    ln -s /opt/vcpkg/vcpkg /usr/local/bin/vcpkg && \
+    chown -R node:node /opt/vcpkg; \
+  fi
+ENV VCPKG_ROOT=/opt/vcpkg
 
 USER node
 

--- a/skills/devcontainer-setup-advanced/templates/partial-cpp-gcc.dockerfile
+++ b/skills/devcontainer-setup-advanced/templates/partial-cpp-gcc.dockerfile
@@ -1,7 +1,10 @@
 # === C++ (GCC) LANGUAGE ADDITIONS ===
+# Uses apt packages for GCC toolchain (proxy-friendly)
+# ============================================================================
+
 USER root
 
-# Install GCC toolchain and build tools
+# Install GCC toolchain and build tools (via apt - proxy-friendly)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gcc \
     g++ \
@@ -10,16 +13,20 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ninja-build \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Install vcpkg (C++ package manager)
-RUN git clone https://github.com/microsoft/vcpkg.git /opt/vcpkg && \
-    /opt/vcpkg/bootstrap-vcpkg.sh && \
-    ln -s /opt/vcpkg/vcpkg /usr/local/bin/vcpkg && \
-    chown -R node:node /opt/vcpkg
-
 # Set C++ environment variables
 ENV CXX=g++ \
-    CC=gcc \
-    VCPKG_ROOT=/opt/vcpkg
+    CC=gcc
+
+# vcpkg installation - conditional on INSTALL_DEV_TOOLS
+# Requires network access to github.com
+ARG INSTALL_CPP_TOOLS=${INSTALL_DEV_TOOLS:-true}
+RUN if [ "$INSTALL_CPP_TOOLS" = "true" ]; then \
+    git clone https://github.com/microsoft/vcpkg.git /opt/vcpkg && \
+    /opt/vcpkg/bootstrap-vcpkg.sh && \
+    ln -s /opt/vcpkg/vcpkg /usr/local/bin/vcpkg && \
+    chown -R node:node /opt/vcpkg; \
+  fi
+ENV VCPKG_ROOT=/opt/vcpkg
 
 USER node
 

--- a/skills/devcontainer-setup-advanced/templates/partial-go.dockerfile
+++ b/skills/devcontainer-setup-advanced/templates/partial-go.dockerfile
@@ -1,18 +1,21 @@
 # === GO LANGUAGE ADDITIONS ===
+# REQUIRED: Add to base multi-stage sources section:
+#   FROM golang:1.22-bookworm AS go-source
+# ============================================================================
+
 USER root
 
-# Install Go
-ARG GO_VERSION=1.22.0
-RUN wget -O go.tar.gz "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" && \
-    tar -C /usr/local -xzf go.tar.gz && \
-    rm go.tar.gz
+# Copy Go toolchain from official image (proxy-friendly)
+# NOTE: Requires 'go-source' stage in base Dockerfile
+COPY --from=go-source /usr/local/go /usr/local/go
 
 # Set Go environment variables
-ENV GOPATH=/home/node/go \
+ENV GOROOT=/usr/local/go \
+    GOPATH=/home/node/go \
     GOBIN=/home/node/go/bin \
-    PATH=$PATH:/usr/local/go/bin:/home/node/go/bin \
     GO111MODULE=on \
     CGO_ENABLED=1
+ENV PATH=$PATH:/usr/local/go/bin:/home/node/go/bin
 
 # Create Go directories for non-root user
 RUN mkdir -p /home/node/go/bin /home/node/go/pkg /home/node/go/src && \
@@ -20,10 +23,14 @@ RUN mkdir -p /home/node/go/bin /home/node/go/pkg /home/node/go/src && \
 
 USER node
 
-# Install Go development tools
-RUN go install golang.org/x/tools/gopls@latest && \
+# Go development tools - conditional on INSTALL_DEV_TOOLS
+# These require network access to proxy.golang.org
+ARG INSTALL_GO_TOOLS=${INSTALL_DEV_TOOLS:-true}
+RUN if [ "$INSTALL_GO_TOOLS" = "true" ]; then \
+    go install golang.org/x/tools/gopls@latest && \
     go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest && \
     go install golang.org/x/tools/cmd/goimports@latest && \
-    go install github.com/go-delve/delve/cmd/dlv@latest
+    go install github.com/go-delve/delve/cmd/dlv@latest; \
+  fi
 
 # === END GO LANGUAGE ADDITIONS ===

--- a/skills/devcontainer-setup-advanced/templates/partial-java.dockerfile
+++ b/skills/devcontainer-setup-advanced/templates/partial-java.dockerfile
@@ -1,31 +1,33 @@
 # === JAVA LANGUAGE ADDITIONS ===
+# REQUIRED: Add to base multi-stage sources section:
+#   FROM eclipse-temurin:21-jdk-jammy AS java-source
+#   FROM maven:3.9-eclipse-temurin-21 AS maven-source
+#   FROM gradle:8.5-jdk21 AS gradle-source
+# ============================================================================
+
 USER root
 
-# Install OpenJDK
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    openjdk-21-jdk \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
+# Copy Java from Eclipse Temurin image (proxy-friendly)
+# NOTE: Requires 'java-source' stage in base Dockerfile
+COPY --from=java-source /opt/java/openjdk /opt/java/openjdk
 
-# Install Maven
-ARG MAVEN_VERSION=3.9.6
-RUN curl -fsSL https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz | \
-    tar xz -C /opt && \
-    ln -s /opt/apache-maven-${MAVEN_VERSION} /opt/maven && \
-    ln -s /opt/maven/bin/mvn /usr/local/bin/mvn
+# Copy Maven from official image (proxy-friendly)
+# NOTE: Requires 'maven-source' stage in base Dockerfile
+COPY --from=maven-source /usr/share/maven /opt/maven
 
-# Install Gradle
-ARG GRADLE_VERSION=8.5
-RUN curl -fsSL https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip -o /tmp/gradle.zip && \
-    unzip -q /tmp/gradle.zip -d /opt && \
-    ln -s /opt/gradle-${GRADLE_VERSION} /opt/gradle && \
-    ln -s /opt/gradle/bin/gradle /usr/local/bin/gradle && \
-    rm /tmp/gradle.zip
+# Copy Gradle from official image (proxy-friendly)
+# NOTE: Requires 'gradle-source' stage in base Dockerfile
+COPY --from=gradle-source /opt/gradle /opt/gradle
 
 # Set Java environment variables
-ENV JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 \
+ENV JAVA_HOME=/opt/java/openjdk \
     MAVEN_HOME=/opt/maven \
     GRADLE_HOME=/opt/gradle \
-    PATH=$PATH:$MAVEN_HOME/bin:$GRADLE_HOME/bin
+    PATH=/opt/java/openjdk/bin:/opt/maven/bin:/opt/gradle/bin:$PATH
+
+# Create symlinks for convenience
+RUN ln -sf /opt/maven/bin/mvn /usr/local/bin/mvn && \
+    ln -sf /opt/gradle/bin/gradle /usr/local/bin/gradle
 
 USER node
 

--- a/skills/devcontainer-setup-advanced/templates/partial-php.dockerfile
+++ b/skills/devcontainer-setup-advanced/templates/partial-php.dockerfile
@@ -1,30 +1,42 @@
 # === PHP LANGUAGE ADDITIONS ===
+# REQUIRED: Add to base multi-stage sources section:
+#   FROM php:8.3-cli-bookworm AS php-source
+#   FROM composer:2 AS composer-source
+# ============================================================================
+
 USER root
 
-# Install PHP and required extensions
+# Copy PHP from official image (proxy-friendly)
+# NOTE: Requires 'php-source' stage in base Dockerfile
+COPY --from=php-source /usr/local/bin/php /usr/local/bin/
+COPY --from=php-source /usr/local/lib/php /usr/local/lib/php
+COPY --from=php-source /usr/local/etc/php /usr/local/etc/php
+
+# Copy Composer from official image (proxy-friendly)
+# NOTE: Requires 'composer-source' stage in base Dockerfile
+COPY --from=composer-source /usr/bin/composer /usr/local/bin/composer
+
+# Install PHP extension dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    php-cli \
-    php-mbstring \
-    php-xml \
-    php-curl \
-    php-zip \
-    php-mysql \
-    php-pgsql \
-    php-sqlite3 \
-    php-gd \
-    php-opcache \
     libzip-dev \
     libpng-dev \
+    libicu-dev \
+    libpq-dev \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Install Composer
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-
 # Configure PHP
-RUN mkdir -p /etc/php/*/cli/conf.d && \
-    echo "memory_limit = 512M" >> /etc/php/*/cli/conf.d/99-custom.ini && \
-    echo "upload_max_filesize = 64M" >> /etc/php/*/cli/conf.d/99-custom.ini && \
-    echo "post_max_size = 64M" >> /etc/php/*/cli/conf.d/99-custom.ini
+RUN mkdir -p /usr/local/etc/php/conf.d && \
+    echo "memory_limit = 512M" >> /usr/local/etc/php/conf.d/99-custom.ini && \
+    echo "upload_max_filesize = 64M" >> /usr/local/etc/php/conf.d/99-custom.ini && \
+    echo "post_max_size = 64M" >> /usr/local/etc/php/conf.d/99-custom.ini
+
+# Set PHP environment
+ENV PATH=/usr/local/bin:$PATH \
+    COMPOSER_HOME=/home/node/.composer
+
+# Create composer directory for user
+RUN mkdir -p /home/node/.composer && \
+    chown -R node:node /home/node/.composer
 
 USER node
 

--- a/skills/devcontainer-setup-advanced/templates/partial-ruby.dockerfile
+++ b/skills/devcontainer-setup-advanced/templates/partial-ruby.dockerfile
@@ -1,25 +1,39 @@
 # === RUBY LANGUAGE ADDITIONS ===
+# REQUIRED: Add to base multi-stage sources section:
+#   FROM ruby:3.3-bookworm AS ruby-source
+# ============================================================================
+
 USER root
 
-# Install Ruby
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ruby-full \
-    ruby-dev \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
+# Copy Ruby from official image (proxy-friendly)
+# NOTE: Requires 'ruby-source' stage in base Dockerfile
+COPY --from=ruby-source /usr/local/bin/ruby /usr/local/bin/
+COPY --from=ruby-source /usr/local/bin/gem /usr/local/bin/
+COPY --from=ruby-source /usr/local/bin/bundle /usr/local/bin/
+COPY --from=ruby-source /usr/local/bin/bundler /usr/local/bin/
+COPY --from=ruby-source /usr/local/lib/ruby /usr/local/lib/ruby
+COPY --from=ruby-source /usr/local/include/ruby* /usr/local/include/
 
-# Install bundler and common gems
-RUN gem update --system && \
-    gem install bundler && \
-    gem install rake rspec rubocop
+# Install ruby build dependencies (needed for native gems)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libyaml-dev libffi-dev \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Configure gem installation for user
 RUN mkdir -p /home/node/.gem && \
     chown -R node:node /home/node/.gem
 
-USER node
-
 # Set Ruby environment variables
 ENV GEM_HOME=/home/node/.gem \
-    PATH=/home/node/.gem/bin:$PATH
+    PATH=/home/node/.gem/bin:/usr/local/bin:$PATH
+
+USER node
+
+# Ruby development tools - conditional on INSTALL_DEV_TOOLS
+# These require network access to rubygems.org
+ARG INSTALL_RUBY_TOOLS=${INSTALL_DEV_TOOLS:-true}
+RUN if [ "$INSTALL_RUBY_TOOLS" = "true" ]; then \
+    gem install rake rspec rubocop; \
+  fi
 
 # === END RUBY LANGUAGE ADDITIONS ===

--- a/skills/devcontainer-setup-basic/templates/partial-cpp-clang.dockerfile
+++ b/skills/devcontainer-setup-basic/templates/partial-cpp-clang.dockerfile
@@ -1,26 +1,47 @@
 # === C++ (CLANG) LANGUAGE ADDITIONS ===
+# Uses LLVM's official apt repository for latest Clang (proxy-friendly via apt)
+# ============================================================================
+
 USER root
 
-# Install Clang toolchain and build tools
+# Add LLVM apt repository for latest Clang toolchain
+# The GPG key download is one-time during build
+RUN wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /usr/share/keyrings/llvm.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/llvm.gpg] http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-17 main" \
+    > /etc/apt/sources.list.d/llvm.list
+
+# Install Clang 17 toolchain and build tools (via apt - proxy-friendly)
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    clang \
-    clang-format \
-    clang-tidy \
-    lldb \
+    clang-17 \
+    clang-format-17 \
+    clang-tidy-17 \
+    lldb-17 \
+    lld-17 \
     cmake \
     ninja-build \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Install vcpkg (C++ package manager)
-RUN git clone https://github.com/microsoft/vcpkg.git /opt/vcpkg && \
-    /opt/vcpkg/bootstrap-vcpkg.sh && \
-    ln -s /opt/vcpkg/vcpkg /usr/local/bin/vcpkg && \
-    chown -R node:node /opt/vcpkg
+# Create version-agnostic symlinks
+RUN ln -sf /usr/bin/clang-17 /usr/bin/clang && \
+    ln -sf /usr/bin/clang++-17 /usr/bin/clang++ && \
+    ln -sf /usr/bin/clang-format-17 /usr/bin/clang-format && \
+    ln -sf /usr/bin/clang-tidy-17 /usr/bin/clang-tidy && \
+    ln -sf /usr/bin/lldb-17 /usr/bin/lldb
 
 # Set C++ environment variables for Clang
 ENV CXX=clang++ \
-    CC=clang \
-    VCPKG_ROOT=/opt/vcpkg
+    CC=clang
+
+# vcpkg installation - conditional on INSTALL_DEV_TOOLS
+# Requires network access to github.com
+ARG INSTALL_CPP_TOOLS=${INSTALL_DEV_TOOLS:-true}
+RUN if [ "$INSTALL_CPP_TOOLS" = "true" ]; then \
+    git clone https://github.com/microsoft/vcpkg.git /opt/vcpkg && \
+    /opt/vcpkg/bootstrap-vcpkg.sh && \
+    ln -s /opt/vcpkg/vcpkg /usr/local/bin/vcpkg && \
+    chown -R node:node /opt/vcpkg; \
+  fi
+ENV VCPKG_ROOT=/opt/vcpkg
 
 USER node
 

--- a/skills/devcontainer-setup-basic/templates/partial-cpp-gcc.dockerfile
+++ b/skills/devcontainer-setup-basic/templates/partial-cpp-gcc.dockerfile
@@ -1,7 +1,10 @@
 # === C++ (GCC) LANGUAGE ADDITIONS ===
+# Uses apt packages for GCC toolchain (proxy-friendly)
+# ============================================================================
+
 USER root
 
-# Install GCC toolchain and build tools
+# Install GCC toolchain and build tools (via apt - proxy-friendly)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gcc \
     g++ \
@@ -10,16 +13,20 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ninja-build \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Install vcpkg (C++ package manager)
-RUN git clone https://github.com/microsoft/vcpkg.git /opt/vcpkg && \
-    /opt/vcpkg/bootstrap-vcpkg.sh && \
-    ln -s /opt/vcpkg/vcpkg /usr/local/bin/vcpkg && \
-    chown -R node:node /opt/vcpkg
-
 # Set C++ environment variables
 ENV CXX=g++ \
-    CC=gcc \
-    VCPKG_ROOT=/opt/vcpkg
+    CC=gcc
+
+# vcpkg installation - conditional on INSTALL_DEV_TOOLS
+# Requires network access to github.com
+ARG INSTALL_CPP_TOOLS=${INSTALL_DEV_TOOLS:-true}
+RUN if [ "$INSTALL_CPP_TOOLS" = "true" ]; then \
+    git clone https://github.com/microsoft/vcpkg.git /opt/vcpkg && \
+    /opt/vcpkg/bootstrap-vcpkg.sh && \
+    ln -s /opt/vcpkg/vcpkg /usr/local/bin/vcpkg && \
+    chown -R node:node /opt/vcpkg; \
+  fi
+ENV VCPKG_ROOT=/opt/vcpkg
 
 USER node
 

--- a/skills/devcontainer-setup-basic/templates/partial-go.dockerfile
+++ b/skills/devcontainer-setup-basic/templates/partial-go.dockerfile
@@ -1,18 +1,21 @@
 # === GO LANGUAGE ADDITIONS ===
+# REQUIRED: Add to base multi-stage sources section:
+#   FROM golang:1.22-bookworm AS go-source
+# ============================================================================
+
 USER root
 
-# Install Go
-ARG GO_VERSION=1.22.0
-RUN wget -O go.tar.gz "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" && \
-    tar -C /usr/local -xzf go.tar.gz && \
-    rm go.tar.gz
+# Copy Go toolchain from official image (proxy-friendly)
+# NOTE: Requires 'go-source' stage in base Dockerfile
+COPY --from=go-source /usr/local/go /usr/local/go
 
 # Set Go environment variables
-ENV GOPATH=/home/node/go \
+ENV GOROOT=/usr/local/go \
+    GOPATH=/home/node/go \
     GOBIN=/home/node/go/bin \
-    PATH=$PATH:/usr/local/go/bin:/home/node/go/bin \
     GO111MODULE=on \
     CGO_ENABLED=1
+ENV PATH=$PATH:/usr/local/go/bin:/home/node/go/bin
 
 # Create Go directories for non-root user
 RUN mkdir -p /home/node/go/bin /home/node/go/pkg /home/node/go/src && \
@@ -20,10 +23,14 @@ RUN mkdir -p /home/node/go/bin /home/node/go/pkg /home/node/go/src && \
 
 USER node
 
-# Install Go development tools
-RUN go install golang.org/x/tools/gopls@latest && \
+# Go development tools - conditional on INSTALL_DEV_TOOLS
+# These require network access to proxy.golang.org
+ARG INSTALL_GO_TOOLS=${INSTALL_DEV_TOOLS:-true}
+RUN if [ "$INSTALL_GO_TOOLS" = "true" ]; then \
+    go install golang.org/x/tools/gopls@latest && \
     go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest && \
     go install golang.org/x/tools/cmd/goimports@latest && \
-    go install github.com/go-delve/delve/cmd/dlv@latest
+    go install github.com/go-delve/delve/cmd/dlv@latest; \
+  fi
 
 # === END GO LANGUAGE ADDITIONS ===

--- a/skills/devcontainer-setup-basic/templates/partial-java.dockerfile
+++ b/skills/devcontainer-setup-basic/templates/partial-java.dockerfile
@@ -1,31 +1,33 @@
 # === JAVA LANGUAGE ADDITIONS ===
+# REQUIRED: Add to base multi-stage sources section:
+#   FROM eclipse-temurin:21-jdk-jammy AS java-source
+#   FROM maven:3.9-eclipse-temurin-21 AS maven-source
+#   FROM gradle:8.5-jdk21 AS gradle-source
+# ============================================================================
+
 USER root
 
-# Install OpenJDK
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    openjdk-21-jdk \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
+# Copy Java from Eclipse Temurin image (proxy-friendly)
+# NOTE: Requires 'java-source' stage in base Dockerfile
+COPY --from=java-source /opt/java/openjdk /opt/java/openjdk
 
-# Install Maven
-ARG MAVEN_VERSION=3.9.6
-RUN curl -fsSL https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz | \
-    tar xz -C /opt && \
-    ln -s /opt/apache-maven-${MAVEN_VERSION} /opt/maven && \
-    ln -s /opt/maven/bin/mvn /usr/local/bin/mvn
+# Copy Maven from official image (proxy-friendly)
+# NOTE: Requires 'maven-source' stage in base Dockerfile
+COPY --from=maven-source /usr/share/maven /opt/maven
 
-# Install Gradle
-ARG GRADLE_VERSION=8.5
-RUN curl -fsSL https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip -o /tmp/gradle.zip && \
-    unzip -q /tmp/gradle.zip -d /opt && \
-    ln -s /opt/gradle-${GRADLE_VERSION} /opt/gradle && \
-    ln -s /opt/gradle/bin/gradle /usr/local/bin/gradle && \
-    rm /tmp/gradle.zip
+# Copy Gradle from official image (proxy-friendly)
+# NOTE: Requires 'gradle-source' stage in base Dockerfile
+COPY --from=gradle-source /opt/gradle /opt/gradle
 
 # Set Java environment variables
-ENV JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 \
+ENV JAVA_HOME=/opt/java/openjdk \
     MAVEN_HOME=/opt/maven \
     GRADLE_HOME=/opt/gradle \
-    PATH=$PATH:$MAVEN_HOME/bin:$GRADLE_HOME/bin
+    PATH=/opt/java/openjdk/bin:/opt/maven/bin:/opt/gradle/bin:$PATH
+
+# Create symlinks for convenience
+RUN ln -sf /opt/maven/bin/mvn /usr/local/bin/mvn && \
+    ln -sf /opt/gradle/bin/gradle /usr/local/bin/gradle
 
 USER node
 

--- a/skills/devcontainer-setup-basic/templates/partial-php.dockerfile
+++ b/skills/devcontainer-setup-basic/templates/partial-php.dockerfile
@@ -1,30 +1,42 @@
 # === PHP LANGUAGE ADDITIONS ===
+# REQUIRED: Add to base multi-stage sources section:
+#   FROM php:8.3-cli-bookworm AS php-source
+#   FROM composer:2 AS composer-source
+# ============================================================================
+
 USER root
 
-# Install PHP and required extensions
+# Copy PHP from official image (proxy-friendly)
+# NOTE: Requires 'php-source' stage in base Dockerfile
+COPY --from=php-source /usr/local/bin/php /usr/local/bin/
+COPY --from=php-source /usr/local/lib/php /usr/local/lib/php
+COPY --from=php-source /usr/local/etc/php /usr/local/etc/php
+
+# Copy Composer from official image (proxy-friendly)
+# NOTE: Requires 'composer-source' stage in base Dockerfile
+COPY --from=composer-source /usr/bin/composer /usr/local/bin/composer
+
+# Install PHP extension dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    php-cli \
-    php-mbstring \
-    php-xml \
-    php-curl \
-    php-zip \
-    php-mysql \
-    php-pgsql \
-    php-sqlite3 \
-    php-gd \
-    php-opcache \
     libzip-dev \
     libpng-dev \
+    libicu-dev \
+    libpq-dev \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Install Composer
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-
 # Configure PHP
-RUN mkdir -p /etc/php/*/cli/conf.d && \
-    echo "memory_limit = 512M" >> /etc/php/*/cli/conf.d/99-custom.ini && \
-    echo "upload_max_filesize = 64M" >> /etc/php/*/cli/conf.d/99-custom.ini && \
-    echo "post_max_size = 64M" >> /etc/php/*/cli/conf.d/99-custom.ini
+RUN mkdir -p /usr/local/etc/php/conf.d && \
+    echo "memory_limit = 512M" >> /usr/local/etc/php/conf.d/99-custom.ini && \
+    echo "upload_max_filesize = 64M" >> /usr/local/etc/php/conf.d/99-custom.ini && \
+    echo "post_max_size = 64M" >> /usr/local/etc/php/conf.d/99-custom.ini
+
+# Set PHP environment
+ENV PATH=/usr/local/bin:$PATH \
+    COMPOSER_HOME=/home/node/.composer
+
+# Create composer directory for user
+RUN mkdir -p /home/node/.composer && \
+    chown -R node:node /home/node/.composer
 
 USER node
 

--- a/skills/devcontainer-setup-basic/templates/partial-ruby.dockerfile
+++ b/skills/devcontainer-setup-basic/templates/partial-ruby.dockerfile
@@ -1,25 +1,39 @@
 # === RUBY LANGUAGE ADDITIONS ===
+# REQUIRED: Add to base multi-stage sources section:
+#   FROM ruby:3.3-bookworm AS ruby-source
+# ============================================================================
+
 USER root
 
-# Install Ruby
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ruby-full \
-    ruby-dev \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
+# Copy Ruby from official image (proxy-friendly)
+# NOTE: Requires 'ruby-source' stage in base Dockerfile
+COPY --from=ruby-source /usr/local/bin/ruby /usr/local/bin/
+COPY --from=ruby-source /usr/local/bin/gem /usr/local/bin/
+COPY --from=ruby-source /usr/local/bin/bundle /usr/local/bin/
+COPY --from=ruby-source /usr/local/bin/bundler /usr/local/bin/
+COPY --from=ruby-source /usr/local/lib/ruby /usr/local/lib/ruby
+COPY --from=ruby-source /usr/local/include/ruby* /usr/local/include/
 
-# Install bundler and common gems
-RUN gem update --system && \
-    gem install bundler && \
-    gem install rake rspec rubocop
+# Install ruby build dependencies (needed for native gems)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libyaml-dev libffi-dev \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Configure gem installation for user
 RUN mkdir -p /home/node/.gem && \
     chown -R node:node /home/node/.gem
 
-USER node
-
 # Set Ruby environment variables
 ENV GEM_HOME=/home/node/.gem \
-    PATH=/home/node/.gem/bin:$PATH
+    PATH=/home/node/.gem/bin:/usr/local/bin:$PATH
+
+USER node
+
+# Ruby development tools - conditional on INSTALL_DEV_TOOLS
+# These require network access to rubygems.org
+ARG INSTALL_RUBY_TOOLS=${INSTALL_DEV_TOOLS:-true}
+RUN if [ "$INSTALL_RUBY_TOOLS" = "true" ]; then \
+    gem install rake rspec rubocop; \
+  fi
 
 # === END RUBY LANGUAGE ADDITIONS ===

--- a/skills/devcontainer-setup-yolo/SKILL.md
+++ b/skills/devcontainer-setup-yolo/SKILL.md
@@ -522,11 +522,40 @@ For each service, ask:
 
 #### E. Build Arguments
 Ask which build args to customize:
+
+**Proxy-Friendly Build Args** (for corporate environments):
+- `INSTALL_SHELL_EXTRAS` - Install git-delta, zsh plugins (default: true)
+  - Set to `false` to skip GitHub downloads behind proxies
+- `INSTALL_DEV_TOOLS` - Install language dev tools like linters, LSPs (default: true)
+  - Set to `false` for minimal builds
+
+**Per-Language Dev Tool Overrides** (inherit from INSTALL_DEV_TOOLS):
+- `INSTALL_GO_TOOLS` - gopls, golangci-lint, delve (default: ${INSTALL_DEV_TOOLS})
+- `INSTALL_RUST_TOOLS` - rustfmt, clippy, cargo extensions (default: ${INSTALL_DEV_TOOLS})
+- `INSTALL_RUBY_TOOLS` - rubocop, rspec, rake (default: ${INSTALL_DEV_TOOLS})
+- `INSTALL_CPP_TOOLS` - vcpkg (default: ${INSTALL_DEV_TOOLS})
+
+**Standard Build Args**:
 - `TZ` - Timezone (default: America/Los_Angeles)
 - `CLAUDE_CODE_VERSION` - Claude Code version (default: latest)
 - `GIT_DELTA_VERSION` - git-delta version (default: 0.18.2)
 - `ZSH_IN_DOCKER_VERSION` - ZSH installer version (default: 1.2.0)
 - Custom build args?
+
+**Example docker-compose.yml for proxy-friendly build:**
+```yaml
+services:
+  app:
+    build:
+      context: .
+      dockerfile: .devcontainer/Dockerfile
+      args:
+        INSTALL_SHELL_EXTRAS: "false"
+        INSTALL_DEV_TOOLS: "false"
+        # Or selectively disable specific language tools:
+        INSTALL_GO_TOOLS: "false"
+        INSTALL_RUST_TOOLS: "true"
+```
 
 #### F. VS Code Configuration
 Ask which VS Code extensions to include:

--- a/skills/devcontainer-setup-yolo/templates/partial-cpp-clang.dockerfile
+++ b/skills/devcontainer-setup-yolo/templates/partial-cpp-clang.dockerfile
@@ -1,26 +1,47 @@
 # === C++ (CLANG) LANGUAGE ADDITIONS ===
+# Uses LLVM's official apt repository for latest Clang (proxy-friendly via apt)
+# ============================================================================
+
 USER root
 
-# Install Clang toolchain and build tools
+# Add LLVM apt repository for latest Clang toolchain
+# The GPG key download is one-time during build
+RUN wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /usr/share/keyrings/llvm.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/llvm.gpg] http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-17 main" \
+    > /etc/apt/sources.list.d/llvm.list
+
+# Install Clang 17 toolchain and build tools (via apt - proxy-friendly)
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    clang \
-    clang-format \
-    clang-tidy \
-    lldb \
+    clang-17 \
+    clang-format-17 \
+    clang-tidy-17 \
+    lldb-17 \
+    lld-17 \
     cmake \
     ninja-build \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Install vcpkg (C++ package manager)
-RUN git clone https://github.com/microsoft/vcpkg.git /opt/vcpkg && \
-    /opt/vcpkg/bootstrap-vcpkg.sh && \
-    ln -s /opt/vcpkg/vcpkg /usr/local/bin/vcpkg && \
-    chown -R node:node /opt/vcpkg
+# Create version-agnostic symlinks
+RUN ln -sf /usr/bin/clang-17 /usr/bin/clang && \
+    ln -sf /usr/bin/clang++-17 /usr/bin/clang++ && \
+    ln -sf /usr/bin/clang-format-17 /usr/bin/clang-format && \
+    ln -sf /usr/bin/clang-tidy-17 /usr/bin/clang-tidy && \
+    ln -sf /usr/bin/lldb-17 /usr/bin/lldb
 
 # Set C++ environment variables for Clang
 ENV CXX=clang++ \
-    CC=clang \
-    VCPKG_ROOT=/opt/vcpkg
+    CC=clang
+
+# vcpkg installation - conditional on INSTALL_DEV_TOOLS
+# Requires network access to github.com
+ARG INSTALL_CPP_TOOLS=${INSTALL_DEV_TOOLS:-true}
+RUN if [ "$INSTALL_CPP_TOOLS" = "true" ]; then \
+    git clone https://github.com/microsoft/vcpkg.git /opt/vcpkg && \
+    /opt/vcpkg/bootstrap-vcpkg.sh && \
+    ln -s /opt/vcpkg/vcpkg /usr/local/bin/vcpkg && \
+    chown -R node:node /opt/vcpkg; \
+  fi
+ENV VCPKG_ROOT=/opt/vcpkg
 
 USER node
 

--- a/skills/devcontainer-setup-yolo/templates/partial-cpp-gcc.dockerfile
+++ b/skills/devcontainer-setup-yolo/templates/partial-cpp-gcc.dockerfile
@@ -1,7 +1,10 @@
 # === C++ (GCC) LANGUAGE ADDITIONS ===
+# Uses apt packages for GCC toolchain (proxy-friendly)
+# ============================================================================
+
 USER root
 
-# Install GCC toolchain and build tools
+# Install GCC toolchain and build tools (via apt - proxy-friendly)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gcc \
     g++ \
@@ -10,16 +13,20 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ninja-build \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Install vcpkg (C++ package manager)
-RUN git clone https://github.com/microsoft/vcpkg.git /opt/vcpkg && \
-    /opt/vcpkg/bootstrap-vcpkg.sh && \
-    ln -s /opt/vcpkg/vcpkg /usr/local/bin/vcpkg && \
-    chown -R node:node /opt/vcpkg
-
 # Set C++ environment variables
 ENV CXX=g++ \
-    CC=gcc \
-    VCPKG_ROOT=/opt/vcpkg
+    CC=gcc
+
+# vcpkg installation - conditional on INSTALL_DEV_TOOLS
+# Requires network access to github.com
+ARG INSTALL_CPP_TOOLS=${INSTALL_DEV_TOOLS:-true}
+RUN if [ "$INSTALL_CPP_TOOLS" = "true" ]; then \
+    git clone https://github.com/microsoft/vcpkg.git /opt/vcpkg && \
+    /opt/vcpkg/bootstrap-vcpkg.sh && \
+    ln -s /opt/vcpkg/vcpkg /usr/local/bin/vcpkg && \
+    chown -R node:node /opt/vcpkg; \
+  fi
+ENV VCPKG_ROOT=/opt/vcpkg
 
 USER node
 

--- a/skills/devcontainer-setup-yolo/templates/partial-go.dockerfile
+++ b/skills/devcontainer-setup-yolo/templates/partial-go.dockerfile
@@ -1,18 +1,21 @@
 # === GO LANGUAGE ADDITIONS ===
+# REQUIRED: Add to base multi-stage sources section:
+#   FROM golang:1.22-bookworm AS go-source
+# ============================================================================
+
 USER root
 
-# Install Go
-ARG GO_VERSION=1.22.0
-RUN wget -O go.tar.gz "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" && \
-    tar -C /usr/local -xzf go.tar.gz && \
-    rm go.tar.gz
+# Copy Go toolchain from official image (proxy-friendly)
+# NOTE: Requires 'go-source' stage in base Dockerfile
+COPY --from=go-source /usr/local/go /usr/local/go
 
 # Set Go environment variables
-ENV GOPATH=/home/node/go \
+ENV GOROOT=/usr/local/go \
+    GOPATH=/home/node/go \
     GOBIN=/home/node/go/bin \
-    PATH=$PATH:/usr/local/go/bin:/home/node/go/bin \
     GO111MODULE=on \
     CGO_ENABLED=1
+ENV PATH=$PATH:/usr/local/go/bin:/home/node/go/bin
 
 # Create Go directories for non-root user
 RUN mkdir -p /home/node/go/bin /home/node/go/pkg /home/node/go/src && \
@@ -20,10 +23,14 @@ RUN mkdir -p /home/node/go/bin /home/node/go/pkg /home/node/go/src && \
 
 USER node
 
-# Install Go development tools
-RUN go install golang.org/x/tools/gopls@latest && \
+# Go development tools - conditional on INSTALL_DEV_TOOLS
+# These require network access to proxy.golang.org
+ARG INSTALL_GO_TOOLS=${INSTALL_DEV_TOOLS:-true}
+RUN if [ "$INSTALL_GO_TOOLS" = "true" ]; then \
+    go install golang.org/x/tools/gopls@latest && \
     go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest && \
     go install golang.org/x/tools/cmd/goimports@latest && \
-    go install github.com/go-delve/delve/cmd/dlv@latest
+    go install github.com/go-delve/delve/cmd/dlv@latest; \
+  fi
 
 # === END GO LANGUAGE ADDITIONS ===

--- a/skills/devcontainer-setup-yolo/templates/partial-java.dockerfile
+++ b/skills/devcontainer-setup-yolo/templates/partial-java.dockerfile
@@ -1,31 +1,33 @@
 # === JAVA LANGUAGE ADDITIONS ===
+# REQUIRED: Add to base multi-stage sources section:
+#   FROM eclipse-temurin:21-jdk-jammy AS java-source
+#   FROM maven:3.9-eclipse-temurin-21 AS maven-source
+#   FROM gradle:8.5-jdk21 AS gradle-source
+# ============================================================================
+
 USER root
 
-# Install OpenJDK
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    openjdk-21-jdk \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
+# Copy Java from Eclipse Temurin image (proxy-friendly)
+# NOTE: Requires 'java-source' stage in base Dockerfile
+COPY --from=java-source /opt/java/openjdk /opt/java/openjdk
 
-# Install Maven
-ARG MAVEN_VERSION=3.9.6
-RUN curl -fsSL https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz | \
-    tar xz -C /opt && \
-    ln -s /opt/apache-maven-${MAVEN_VERSION} /opt/maven && \
-    ln -s /opt/maven/bin/mvn /usr/local/bin/mvn
+# Copy Maven from official image (proxy-friendly)
+# NOTE: Requires 'maven-source' stage in base Dockerfile
+COPY --from=maven-source /usr/share/maven /opt/maven
 
-# Install Gradle
-ARG GRADLE_VERSION=8.5
-RUN curl -fsSL https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip -o /tmp/gradle.zip && \
-    unzip -q /tmp/gradle.zip -d /opt && \
-    ln -s /opt/gradle-${GRADLE_VERSION} /opt/gradle && \
-    ln -s /opt/gradle/bin/gradle /usr/local/bin/gradle && \
-    rm /tmp/gradle.zip
+# Copy Gradle from official image (proxy-friendly)
+# NOTE: Requires 'gradle-source' stage in base Dockerfile
+COPY --from=gradle-source /opt/gradle /opt/gradle
 
 # Set Java environment variables
-ENV JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 \
+ENV JAVA_HOME=/opt/java/openjdk \
     MAVEN_HOME=/opt/maven \
     GRADLE_HOME=/opt/gradle \
-    PATH=$PATH:$MAVEN_HOME/bin:$GRADLE_HOME/bin
+    PATH=/opt/java/openjdk/bin:/opt/maven/bin:/opt/gradle/bin:$PATH
+
+# Create symlinks for convenience
+RUN ln -sf /opt/maven/bin/mvn /usr/local/bin/mvn && \
+    ln -sf /opt/gradle/bin/gradle /usr/local/bin/gradle
 
 USER node
 

--- a/skills/devcontainer-setup-yolo/templates/partial-php.dockerfile
+++ b/skills/devcontainer-setup-yolo/templates/partial-php.dockerfile
@@ -1,30 +1,42 @@
 # === PHP LANGUAGE ADDITIONS ===
+# REQUIRED: Add to base multi-stage sources section:
+#   FROM php:8.3-cli-bookworm AS php-source
+#   FROM composer:2 AS composer-source
+# ============================================================================
+
 USER root
 
-# Install PHP and required extensions
+# Copy PHP from official image (proxy-friendly)
+# NOTE: Requires 'php-source' stage in base Dockerfile
+COPY --from=php-source /usr/local/bin/php /usr/local/bin/
+COPY --from=php-source /usr/local/lib/php /usr/local/lib/php
+COPY --from=php-source /usr/local/etc/php /usr/local/etc/php
+
+# Copy Composer from official image (proxy-friendly)
+# NOTE: Requires 'composer-source' stage in base Dockerfile
+COPY --from=composer-source /usr/bin/composer /usr/local/bin/composer
+
+# Install PHP extension dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    php-cli \
-    php-mbstring \
-    php-xml \
-    php-curl \
-    php-zip \
-    php-mysql \
-    php-pgsql \
-    php-sqlite3 \
-    php-gd \
-    php-opcache \
     libzip-dev \
     libpng-dev \
+    libicu-dev \
+    libpq-dev \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Install Composer
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-
 # Configure PHP
-RUN mkdir -p /etc/php/*/cli/conf.d && \
-    echo "memory_limit = 512M" >> /etc/php/*/cli/conf.d/99-custom.ini && \
-    echo "upload_max_filesize = 64M" >> /etc/php/*/cli/conf.d/99-custom.ini && \
-    echo "post_max_size = 64M" >> /etc/php/*/cli/conf.d/99-custom.ini
+RUN mkdir -p /usr/local/etc/php/conf.d && \
+    echo "memory_limit = 512M" >> /usr/local/etc/php/conf.d/99-custom.ini && \
+    echo "upload_max_filesize = 64M" >> /usr/local/etc/php/conf.d/99-custom.ini && \
+    echo "post_max_size = 64M" >> /usr/local/etc/php/conf.d/99-custom.ini
+
+# Set PHP environment
+ENV PATH=/usr/local/bin:$PATH \
+    COMPOSER_HOME=/home/node/.composer
+
+# Create composer directory for user
+RUN mkdir -p /home/node/.composer && \
+    chown -R node:node /home/node/.composer
 
 USER node
 

--- a/skills/devcontainer-setup-yolo/templates/partial-ruby.dockerfile
+++ b/skills/devcontainer-setup-yolo/templates/partial-ruby.dockerfile
@@ -1,25 +1,39 @@
 # === RUBY LANGUAGE ADDITIONS ===
+# REQUIRED: Add to base multi-stage sources section:
+#   FROM ruby:3.3-bookworm AS ruby-source
+# ============================================================================
+
 USER root
 
-# Install Ruby
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ruby-full \
-    ruby-dev \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
+# Copy Ruby from official image (proxy-friendly)
+# NOTE: Requires 'ruby-source' stage in base Dockerfile
+COPY --from=ruby-source /usr/local/bin/ruby /usr/local/bin/
+COPY --from=ruby-source /usr/local/bin/gem /usr/local/bin/
+COPY --from=ruby-source /usr/local/bin/bundle /usr/local/bin/
+COPY --from=ruby-source /usr/local/bin/bundler /usr/local/bin/
+COPY --from=ruby-source /usr/local/lib/ruby /usr/local/lib/ruby
+COPY --from=ruby-source /usr/local/include/ruby* /usr/local/include/
 
-# Install bundler and common gems
-RUN gem update --system && \
-    gem install bundler && \
-    gem install rake rspec rubocop
+# Install ruby build dependencies (needed for native gems)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libyaml-dev libffi-dev \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Configure gem installation for user
 RUN mkdir -p /home/node/.gem && \
     chown -R node:node /home/node/.gem
 
-USER node
-
 # Set Ruby environment variables
 ENV GEM_HOME=/home/node/.gem \
-    PATH=/home/node/.gem/bin:$PATH
+    PATH=/home/node/.gem/bin:/usr/local/bin:$PATH
+
+USER node
+
+# Ruby development tools - conditional on INSTALL_DEV_TOOLS
+# These require network access to rubygems.org
+ARG INSTALL_RUBY_TOOLS=${INSTALL_DEV_TOOLS:-true}
+RUN if [ "$INSTALL_RUBY_TOOLS" = "true" ]; then \
+    gem install rake rspec rubocop; \
+  fi
 
 # === END RUBY LANGUAGE ADDITIONS ===

--- a/templates/master/partial-cpp-clang.dockerfile
+++ b/templates/master/partial-cpp-clang.dockerfile
@@ -1,26 +1,47 @@
 # === C++ (CLANG) LANGUAGE ADDITIONS ===
+# Uses LLVM's official apt repository for latest Clang (proxy-friendly via apt)
+# ============================================================================
+
 USER root
 
-# Install Clang toolchain and build tools
+# Add LLVM apt repository for latest Clang toolchain
+# The GPG key download is one-time during build
+RUN wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /usr/share/keyrings/llvm.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/llvm.gpg] http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-17 main" \
+    > /etc/apt/sources.list.d/llvm.list
+
+# Install Clang 17 toolchain and build tools (via apt - proxy-friendly)
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    clang \
-    clang-format \
-    clang-tidy \
-    lldb \
+    clang-17 \
+    clang-format-17 \
+    clang-tidy-17 \
+    lldb-17 \
+    lld-17 \
     cmake \
     ninja-build \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Install vcpkg (C++ package manager)
-RUN git clone https://github.com/microsoft/vcpkg.git /opt/vcpkg && \
-    /opt/vcpkg/bootstrap-vcpkg.sh && \
-    ln -s /opt/vcpkg/vcpkg /usr/local/bin/vcpkg && \
-    chown -R node:node /opt/vcpkg
+# Create version-agnostic symlinks
+RUN ln -sf /usr/bin/clang-17 /usr/bin/clang && \
+    ln -sf /usr/bin/clang++-17 /usr/bin/clang++ && \
+    ln -sf /usr/bin/clang-format-17 /usr/bin/clang-format && \
+    ln -sf /usr/bin/clang-tidy-17 /usr/bin/clang-tidy && \
+    ln -sf /usr/bin/lldb-17 /usr/bin/lldb
 
 # Set C++ environment variables for Clang
 ENV CXX=clang++ \
-    CC=clang \
-    VCPKG_ROOT=/opt/vcpkg
+    CC=clang
+
+# vcpkg installation - conditional on INSTALL_DEV_TOOLS
+# Requires network access to github.com
+ARG INSTALL_CPP_TOOLS=${INSTALL_DEV_TOOLS:-true}
+RUN if [ "$INSTALL_CPP_TOOLS" = "true" ]; then \
+    git clone https://github.com/microsoft/vcpkg.git /opt/vcpkg && \
+    /opt/vcpkg/bootstrap-vcpkg.sh && \
+    ln -s /opt/vcpkg/vcpkg /usr/local/bin/vcpkg && \
+    chown -R node:node /opt/vcpkg; \
+  fi
+ENV VCPKG_ROOT=/opt/vcpkg
 
 USER node
 

--- a/templates/master/partial-cpp-gcc.dockerfile
+++ b/templates/master/partial-cpp-gcc.dockerfile
@@ -1,7 +1,10 @@
 # === C++ (GCC) LANGUAGE ADDITIONS ===
+# Uses apt packages for GCC toolchain (proxy-friendly)
+# ============================================================================
+
 USER root
 
-# Install GCC toolchain and build tools
+# Install GCC toolchain and build tools (via apt - proxy-friendly)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gcc \
     g++ \
@@ -10,16 +13,20 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ninja-build \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Install vcpkg (C++ package manager)
-RUN git clone https://github.com/microsoft/vcpkg.git /opt/vcpkg && \
-    /opt/vcpkg/bootstrap-vcpkg.sh && \
-    ln -s /opt/vcpkg/vcpkg /usr/local/bin/vcpkg && \
-    chown -R node:node /opt/vcpkg
-
 # Set C++ environment variables
 ENV CXX=g++ \
-    CC=gcc \
-    VCPKG_ROOT=/opt/vcpkg
+    CC=gcc
+
+# vcpkg installation - conditional on INSTALL_DEV_TOOLS
+# Requires network access to github.com
+ARG INSTALL_CPP_TOOLS=${INSTALL_DEV_TOOLS:-true}
+RUN if [ "$INSTALL_CPP_TOOLS" = "true" ]; then \
+    git clone https://github.com/microsoft/vcpkg.git /opt/vcpkg && \
+    /opt/vcpkg/bootstrap-vcpkg.sh && \
+    ln -s /opt/vcpkg/vcpkg /usr/local/bin/vcpkg && \
+    chown -R node:node /opt/vcpkg; \
+  fi
+ENV VCPKG_ROOT=/opt/vcpkg
 
 USER node
 

--- a/templates/master/partial-go.dockerfile
+++ b/templates/master/partial-go.dockerfile
@@ -1,18 +1,21 @@
 # === GO LANGUAGE ADDITIONS ===
+# REQUIRED: Add to base multi-stage sources section:
+#   FROM golang:1.22-bookworm AS go-source
+# ============================================================================
+
 USER root
 
-# Install Go
-ARG GO_VERSION=1.22.0
-RUN wget -O go.tar.gz "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" && \
-    tar -C /usr/local -xzf go.tar.gz && \
-    rm go.tar.gz
+# Copy Go toolchain from official image (proxy-friendly)
+# NOTE: Requires 'go-source' stage in base Dockerfile
+COPY --from=go-source /usr/local/go /usr/local/go
 
 # Set Go environment variables
-ENV GOPATH=/home/node/go \
+ENV GOROOT=/usr/local/go \
+    GOPATH=/home/node/go \
     GOBIN=/home/node/go/bin \
-    PATH=$PATH:/usr/local/go/bin:/home/node/go/bin \
     GO111MODULE=on \
     CGO_ENABLED=1
+ENV PATH=$PATH:/usr/local/go/bin:/home/node/go/bin
 
 # Create Go directories for non-root user
 RUN mkdir -p /home/node/go/bin /home/node/go/pkg /home/node/go/src && \
@@ -20,10 +23,14 @@ RUN mkdir -p /home/node/go/bin /home/node/go/pkg /home/node/go/src && \
 
 USER node
 
-# Install Go development tools
-RUN go install golang.org/x/tools/gopls@latest && \
+# Go development tools - conditional on INSTALL_DEV_TOOLS
+# These require network access to proxy.golang.org
+ARG INSTALL_GO_TOOLS=${INSTALL_DEV_TOOLS:-true}
+RUN if [ "$INSTALL_GO_TOOLS" = "true" ]; then \
+    go install golang.org/x/tools/gopls@latest && \
     go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest && \
     go install golang.org/x/tools/cmd/goimports@latest && \
-    go install github.com/go-delve/delve/cmd/dlv@latest
+    go install github.com/go-delve/delve/cmd/dlv@latest; \
+  fi
 
 # === END GO LANGUAGE ADDITIONS ===

--- a/templates/master/partial-java.dockerfile
+++ b/templates/master/partial-java.dockerfile
@@ -1,31 +1,33 @@
 # === JAVA LANGUAGE ADDITIONS ===
+# REQUIRED: Add to base multi-stage sources section:
+#   FROM eclipse-temurin:21-jdk-jammy AS java-source
+#   FROM maven:3.9-eclipse-temurin-21 AS maven-source
+#   FROM gradle:8.5-jdk21 AS gradle-source
+# ============================================================================
+
 USER root
 
-# Install OpenJDK
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    openjdk-21-jdk \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
+# Copy Java from Eclipse Temurin image (proxy-friendly)
+# NOTE: Requires 'java-source' stage in base Dockerfile
+COPY --from=java-source /opt/java/openjdk /opt/java/openjdk
 
-# Install Maven
-ARG MAVEN_VERSION=3.9.6
-RUN curl -fsSL https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz | \
-    tar xz -C /opt && \
-    ln -s /opt/apache-maven-${MAVEN_VERSION} /opt/maven && \
-    ln -s /opt/maven/bin/mvn /usr/local/bin/mvn
+# Copy Maven from official image (proxy-friendly)
+# NOTE: Requires 'maven-source' stage in base Dockerfile
+COPY --from=maven-source /usr/share/maven /opt/maven
 
-# Install Gradle
-ARG GRADLE_VERSION=8.5
-RUN curl -fsSL https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip -o /tmp/gradle.zip && \
-    unzip -q /tmp/gradle.zip -d /opt && \
-    ln -s /opt/gradle-${GRADLE_VERSION} /opt/gradle && \
-    ln -s /opt/gradle/bin/gradle /usr/local/bin/gradle && \
-    rm /tmp/gradle.zip
+# Copy Gradle from official image (proxy-friendly)
+# NOTE: Requires 'gradle-source' stage in base Dockerfile
+COPY --from=gradle-source /opt/gradle /opt/gradle
 
 # Set Java environment variables
-ENV JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 \
+ENV JAVA_HOME=/opt/java/openjdk \
     MAVEN_HOME=/opt/maven \
     GRADLE_HOME=/opt/gradle \
-    PATH=$PATH:$MAVEN_HOME/bin:$GRADLE_HOME/bin
+    PATH=/opt/java/openjdk/bin:/opt/maven/bin:/opt/gradle/bin:$PATH
+
+# Create symlinks for convenience
+RUN ln -sf /opt/maven/bin/mvn /usr/local/bin/mvn && \
+    ln -sf /opt/gradle/bin/gradle /usr/local/bin/gradle
 
 USER node
 

--- a/templates/master/partial-php.dockerfile
+++ b/templates/master/partial-php.dockerfile
@@ -1,30 +1,42 @@
 # === PHP LANGUAGE ADDITIONS ===
+# REQUIRED: Add to base multi-stage sources section:
+#   FROM php:8.3-cli-bookworm AS php-source
+#   FROM composer:2 AS composer-source
+# ============================================================================
+
 USER root
 
-# Install PHP and required extensions
+# Copy PHP from official image (proxy-friendly)
+# NOTE: Requires 'php-source' stage in base Dockerfile
+COPY --from=php-source /usr/local/bin/php /usr/local/bin/
+COPY --from=php-source /usr/local/lib/php /usr/local/lib/php
+COPY --from=php-source /usr/local/etc/php /usr/local/etc/php
+
+# Copy Composer from official image (proxy-friendly)
+# NOTE: Requires 'composer-source' stage in base Dockerfile
+COPY --from=composer-source /usr/bin/composer /usr/local/bin/composer
+
+# Install PHP extension dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    php-cli \
-    php-mbstring \
-    php-xml \
-    php-curl \
-    php-zip \
-    php-mysql \
-    php-pgsql \
-    php-sqlite3 \
-    php-gd \
-    php-opcache \
     libzip-dev \
     libpng-dev \
+    libicu-dev \
+    libpq-dev \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Install Composer
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-
 # Configure PHP
-RUN mkdir -p /etc/php/*/cli/conf.d && \
-    echo "memory_limit = 512M" >> /etc/php/*/cli/conf.d/99-custom.ini && \
-    echo "upload_max_filesize = 64M" >> /etc/php/*/cli/conf.d/99-custom.ini && \
-    echo "post_max_size = 64M" >> /etc/php/*/cli/conf.d/99-custom.ini
+RUN mkdir -p /usr/local/etc/php/conf.d && \
+    echo "memory_limit = 512M" >> /usr/local/etc/php/conf.d/99-custom.ini && \
+    echo "upload_max_filesize = 64M" >> /usr/local/etc/php/conf.d/99-custom.ini && \
+    echo "post_max_size = 64M" >> /usr/local/etc/php/conf.d/99-custom.ini
+
+# Set PHP environment
+ENV PATH=/usr/local/bin:$PATH \
+    COMPOSER_HOME=/home/node/.composer
+
+# Create composer directory for user
+RUN mkdir -p /home/node/.composer && \
+    chown -R node:node /home/node/.composer
 
 USER node
 

--- a/templates/master/partial-ruby.dockerfile
+++ b/templates/master/partial-ruby.dockerfile
@@ -1,25 +1,39 @@
 # === RUBY LANGUAGE ADDITIONS ===
+# REQUIRED: Add to base multi-stage sources section:
+#   FROM ruby:3.3-bookworm AS ruby-source
+# ============================================================================
+
 USER root
 
-# Install Ruby
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ruby-full \
-    ruby-dev \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
+# Copy Ruby from official image (proxy-friendly)
+# NOTE: Requires 'ruby-source' stage in base Dockerfile
+COPY --from=ruby-source /usr/local/bin/ruby /usr/local/bin/
+COPY --from=ruby-source /usr/local/bin/gem /usr/local/bin/
+COPY --from=ruby-source /usr/local/bin/bundle /usr/local/bin/
+COPY --from=ruby-source /usr/local/bin/bundler /usr/local/bin/
+COPY --from=ruby-source /usr/local/lib/ruby /usr/local/lib/ruby
+COPY --from=ruby-source /usr/local/include/ruby* /usr/local/include/
 
-# Install bundler and common gems
-RUN gem update --system && \
-    gem install bundler && \
-    gem install rake rspec rubocop
+# Install ruby build dependencies (needed for native gems)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libyaml-dev libffi-dev \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Configure gem installation for user
 RUN mkdir -p /home/node/.gem && \
     chown -R node:node /home/node/.gem
 
-USER node
-
 # Set Ruby environment variables
 ENV GEM_HOME=/home/node/.gem \
-    PATH=/home/node/.gem/bin:$PATH
+    PATH=/home/node/.gem/bin:/usr/local/bin:$PATH
+
+USER node
+
+# Ruby development tools - conditional on INSTALL_DEV_TOOLS
+# These require network access to rubygems.org
+ARG INSTALL_RUBY_TOOLS=${INSTALL_DEV_TOOLS:-true}
+RUN if [ "$INSTALL_RUBY_TOOLS" = "true" ]; then \
+    gem install rake rspec rubocop; \
+  fi
 
 # === END RUBY LANGUAGE ADDITIONS ===


### PR DESCRIPTION
Implement multi-stage COPY pattern for corporate proxy environments:

Base Dockerfile:
- Add INSTALL_SHELL_EXTRAS and INSTALL_DEV_TOOLS global ARGs
- Make git-delta, zsh plugins conditional on INSTALL_SHELL_EXTRAS
- Make Python/Node dev tools conditional on INSTALL_DEV_TOOLS
- Separate core packages from optional dev tooling

Language Partials (proxy-friendly updates):
- Go: Multi-stage COPY from golang:1.22-bookworm, conditional dev tools
- Rust: Multi-stage COPY from rust:1.75-bookworm, conditional tools
- Java: Multi-stage COPY from eclipse-temurin, maven, gradle images
- Ruby: Multi-stage COPY from ruby:3.3-bookworm, conditional gems
- PHP: Multi-stage COPY from php:8.3 and composer:2 images
- C++ GCC: Conditional vcpkg installation
- C++ Clang: Use LLVM apt repo for Clang 17, conditional vcpkg

Skills Updated:
- Advanced mode: Add proxy-friendly question with build args toggle
- YOLO mode: Document all ARGs including per-language overrides

Why multi-stage COPY works behind proxies:
- Docker Hub access typically allowed through corporate proxies
- Avoids wget/curl downloads from go.dev, rustup.rs, etc.
- All dependencies from well-known container registries

Usage:
- Default: All extras and dev tools installed
- Proxy-friendly: Set INSTALL_SHELL_EXTRAS=false, INSTALL_DEV_TOOLS=false

🤖 Generated with [Claude Code](https://claude.com/claude-code)