### PR TITLE
Fix: Add -exist flag to ipset add commands to handle duplicate IPs

### DIFF
--- a/docs/examples/demo-app-sandbox-advanced/.devcontainer/init-firewall.sh
+++ b/docs/examples/demo-app-sandbox-advanced/.devcontainer/init-firewall.sh
@@ -204,7 +204,7 @@ while read -r cidr; do
         exit 1
     fi
     echo "  Adding GitHub range $cidr"
-    ipset add allowed-domains "$cidr"
+    ipset add -exist allowed-domains "$cidr"
 done < <(echo "$gh_ranges" | jq -r '(.web + .api + .git)[]' | aggregate -q)
 
 # ----------------------------------------------------------------------------
@@ -230,7 +230,7 @@ for domain in "${ALLOWED_DOMAINS[@]}"; do
             continue
         fi
         echo "    Adding $ip for $domain"
-        ipset add allowed-domains "$ip"
+        ipset add -exist allowed-domains "$ip"
     done < <(echo "$ips")
 done
 

--- a/docs/examples/demo-app-sandbox-yolo/.devcontainer/init-firewall.sh
+++ b/docs/examples/demo-app-sandbox-yolo/.devcontainer/init-firewall.sh
@@ -464,7 +464,7 @@ while read -r cidr; do
         exit 1
     fi
     echo "  Adding GitHub range $cidr"
-    ipset add allowed-domains "$cidr"
+    ipset add -exist allowed-domains "$cidr"
 done < <(echo "$gh_ranges" | jq -r '(.web + .api + .git)[]' | aggregate -q)
 
 # ----------------------------------------------------------------------------
@@ -490,7 +490,7 @@ for domain in "${ALLOWED_DOMAINS[@]}"; do
             continue
         fi
         echo "    Adding $ip for $domain"
-        ipset add allowed-domains "$ip"
+        ipset add -exist allowed-domains "$ip"
     done < <(echo "$ips")
 done
 

--- a/docs/examples/streamlit-sandbox-basic/.devcontainer/init-firewall.sh
+++ b/docs/examples/streamlit-sandbox-basic/.devcontainer/init-firewall.sh
@@ -176,7 +176,7 @@ while read -r cidr; do
         exit 1
     fi
     echo "  Adding GitHub range $cidr"
-    ipset add allowed-domains "$cidr"
+    ipset add -exist allowed-domains "$cidr"
 done < <(echo "$gh_ranges" | jq -r '(.web + .api + .git)[]' | aggregate -q)
 
 # ----------------------------------------------------------------------------
@@ -198,7 +198,7 @@ for domain in "${ALLOWED_DOMAINS[@]}"; do
             continue
         fi
         echo "    Adding $ip for $domain"
-        ipset add allowed-domains "$ip"
+        ipset add -exist allowed-domains "$ip"
     done < <(echo "$ips")
 done
 

--- a/skills/_shared/templates/init-firewall.sh
+++ b/skills/_shared/templates/init-firewall.sh
@@ -204,7 +204,7 @@ while read -r cidr; do
         exit 1
     fi
     echo "  Adding GitHub range $cidr"
-    ipset add allowed-domains "$cidr"
+    ipset add -exist allowed-domains "$cidr"
 done < <(echo "$gh_ranges" | jq -r '(.web + .api + .git)[]' | aggregate -q)
 
 # ----------------------------------------------------------------------------
@@ -230,7 +230,7 @@ for domain in "${ALLOWED_DOMAINS[@]}"; do
             continue
         fi
         echo "    Adding $ip for $domain"
-        ipset add allowed-domains "$ip"
+        ipset add -exist allowed-domains "$ip"
     done < <(echo "$ips")
 done
 


### PR DESCRIPTION
## Summary
Fixes #7 - DevContainer firewall script fails on duplicate IPs from CDN domains

## Problem
The firewall initialization script failed when multiple domains resolved to the same IP addresses:

```
ipset v7.22: Element cannot be added to the set: it's already added
[265970 ms] postStartCommand from devcontainer.json failed with exit code 1
```

**Root Cause:**
- Multiple domains (e.g., `pypi.org`, `files.pythonhosted.org`) use shared CDN infrastructure
- Both resolve to the same IP address (e.g., `151.101.0.223`)
- `ipset add` fails when attempting to add duplicate IP addresses
- Script exits immediately due to `set -euo pipefail`

## Solution
Added the `-exist` flag to all `ipset add` commands to silently ignore duplicate entries:

```bash
# Before
ipset add allowed-domains "$ip"

# After  
ipset add -exist allowed-domains "$ip"
```

## Changes
**4 files modified (8 line changes):**

- ✅ `skills/_shared/templates/init-firewall.sh` (lines 207, 233)
- ✅ `docs/examples/streamlit-sandbox-basic/.devcontainer/init-firewall.sh` (lines 179, 201)
- ✅ `docs/examples/demo-app-sandbox-advanced/.devcontainer/init-firewall.sh` (lines 207, 233)
- ✅ `docs/examples/demo-app-sandbox-yolo/.devcontainer/init-firewall.sh` (lines 467, 493)

## Testing
- Verified no `ipset add` commands remain without `-exist` flag
- All template and example configurations updated consistently
- No breaking changes to functionality

## Impact
- ✅ Firewall initialization completes successfully with CDN-shared IPs
- ✅ Standard ipset best practice for idempotent operations
- ✅ Prevents postStartCommand failures in DevContainer setup

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>