### PR TITLE
fix: use bash array format for initializeCommand Windows compatibility

### DIFF
--- a/skills/_shared/templates/devcontainer.json
+++ b/skills/_shared/templates/devcontainer.json
@@ -65,7 +65,7 @@
   // 5. postStartCommand - runs each time the container starts
   // 6. postAttachCommand - runs each time VS Code attaches to the container
 
-  "initializeCommand": "if grep -q '{{PROJECT_NAME}}-workspace-volume' docker-compose.yml 2>/dev/null; then docker volume create {{PROJECT_NAME}}-workspace-volume 2>/dev/null || true; fi",
+  "initializeCommand": ["bash", "-c", "if grep -q '{{PROJECT_NAME}}-workspace-volume' docker-compose.yml 2>/dev/null; then docker volume create {{PROJECT_NAME}}-workspace-volume 2>/dev/null || true; fi"],
   "onCreateCommand": "rm -rf /workspace/.venv 2>/dev/null || true; if [ -d '/tmp/host-source' ] && [ -z \"$(ls -A /workspace 2>/dev/null)\" ]; then cp -r /tmp/host-source/. /workspace/; fi",
   "postCreateCommand": ".devcontainer/setup-claude-credentials.sh && .devcontainer/setup-frontend.sh",
   "updateContentCommand": "echo '🧹 Cleaning stale .venv after rebuild...' && rm -rf /workspace/.venv 2>/dev/null || true",


### PR DESCRIPTION
The initializeCommand runs on the HOST machine before container creation. On Windows, VS Code runs string-format commands with cmd.exe, which fails with bash syntax like 'if grep -q ... then ... fi'.

Changed initializeCommand from string to array format ["bash", "-c", "..."] which explicitly invokes Git Bash (typically installed on Windows dev machines) instead of defaulting to cmd.exe.

This fix applies only to the template's initializeCommand since it's the only lifecycle command that runs on the host. All other commands (onCreateCommand, postCreateCommand, etc.) run inside the Linux container where bash is available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)