### PR TITLE
fix: use Docker-only initializeCommand for true cross-platform compat…

### DIFF
--- a/skills/_shared/templates/devcontainer.json
+++ b/skills/_shared/templates/devcontainer.json
@@ -65,7 +65,7 @@
   // 5. postStartCommand - runs each time the container starts
   // 6. postAttachCommand - runs each time VS Code attaches to the container
 
-  "initializeCommand": ["bash", "-c", "if grep -q '{{PROJECT_NAME}}-workspace-volume' docker-compose.yml 2>/dev/null; then docker volume create {{PROJECT_NAME}}-workspace-volume 2>/dev/null || true; fi"],
+  "initializeCommand": ["docker", "volume", "create", "{{PROJECT_NAME}}-workspace-volume"],
   "onCreateCommand": "rm -rf /workspace/.venv 2>/dev/null || true; if [ -d '/tmp/host-source' ] && [ -z \"$(ls -A /workspace 2>/dev/null)\" ]; then cp -r /tmp/host-source/. /workspace/; fi",
   "postCreateCommand": ".devcontainer/setup-claude-credentials.sh && .devcontainer/setup-frontend.sh",
   "updateContentCommand": "echo '🧹 Cleaning stale .venv after rebuild...' && rm -rf /workspace/.venv 2>/dev/null || true",


### PR DESCRIPTION
…ibility

The previous fix using ["bash", "-c", "..."] still failed on Windows:
  WSL ERROR: execvpe(/bin/bash) failed: No such file or directory

Root cause: initializeCommand runs on the HOST machine (Windows/macOS/Linux) before any container exists. Bash and Unix utilities (grep, sh) are not available on Windows hosts, even with array format.

Solution: Use Docker commands directly since docker is always available for DevContainers to work. Changed from conditional bash command to simple:
  ["docker", "volume", "create", "{{PROJECT_NAME}}-workspace-volume"]

Why this works:
- Docker is required for DevContainers (guaranteed to be available)
- Array format bypasses host shell (cmd.exe, PowerShell, bash) entirely
- docker volume create is idempotent (no error if volume already exists)
- Works on Windows, macOS, and Linux without any shell dependencies

Why volume pre-creation is necessary:
- docker-compose.volume.yml declares volumes with "external: true"
- Docker Compose will NOT auto-create external volumes
- Volume must exist before docker-compose up or it fails

Trade-off: Volume is always created even in bind-mount mode (harmless, 0 bytes)

Supersedes commit 760eda8 (bash array format approach that still failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)