### PR TITLE
fix: run fzf shell integration download as root before USER node

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -97,19 +97,20 @@ RUN jq -r '[.categories | to_entries[] | .value | ((.domains // []), (.wildcard_
     /tmp/allowable-domains.json > /etc/claude-allowed-domains.txt && \
     rm /tmp/allowable-domains.json
 
-USER node
-
-# NPM global config
-ENV NPM_CONFIG_PREFIX=/usr/local/share/npm-global
-ENV PATH=$PATH:/usr/local/share/npm-global/bin
-
 # Download fzf shell integration files (not included in Debian package)
 # Issue #110: Debian fzf package doesn't include shell integration scripts
+# Must run as root to write to /usr/share/doc/fzf/examples/
 RUN mkdir -p /usr/share/doc/fzf/examples && \
     wget -q -O /usr/share/doc/fzf/examples/key-bindings.zsh \
       https://raw.githubusercontent.com/junegunn/fzf/master/shell/key-bindings.zsh && \
     wget -q -O /usr/share/doc/fzf/examples/completion.zsh \
       https://raw.githubusercontent.com/junegunn/fzf/master/shell/completion.zsh
+
+USER node
+
+# NPM global config
+ENV NPM_CONFIG_PREFIX=/usr/local/share/npm-global
+ENV PATH=$PATH:/usr/local/share/npm-global/bin
 
 # ZSH with Powerlevel10k
 ARG ZSH_IN_DOCKER_VERSION=1.2.0

--- a/docs/examples/demo-app-sandbox-advanced/.devcontainer/Dockerfile
+++ b/docs/examples/demo-app-sandbox-advanced/.devcontainer/Dockerfile
@@ -72,16 +72,17 @@ RUN ARCH=$(dpkg --print-architecture) && \
 # Set working directory
 WORKDIR /workspace
 
-# Switch to non-root user
-USER node
-
 # Download fzf shell integration files (not included in Debian package)
 # Issue #110: Debian fzf package doesn't include shell integration scripts
+# Must run as root to write to /usr/share/doc/fzf/examples/
 RUN mkdir -p /usr/share/doc/fzf/examples && \
     wget -q -O /usr/share/doc/fzf/examples/key-bindings.zsh \
       https://raw.githubusercontent.com/junegunn/fzf/master/shell/key-bindings.zsh && \
     wget -q -O /usr/share/doc/fzf/examples/completion.zsh \
       https://raw.githubusercontent.com/junegunn/fzf/master/shell/completion.zsh
+
+# Switch to non-root user
+USER node
 
 # Install ZSH with Powerlevel10k (as non-root user)
 ARG ZSH_IN_DOCKER_VERSION=1.2.0

--- a/docs/examples/demo-app-sandbox-basic/.devcontainer/Dockerfile
+++ b/docs/examples/demo-app-sandbox-basic/.devcontainer/Dockerfile
@@ -72,16 +72,17 @@ RUN ARCH=$(dpkg --print-architecture) && \
 # Set working directory
 WORKDIR /workspace
 
-# Switch to non-root user
-USER node
-
 # Download fzf shell integration files (not included in Debian package)
 # Issue #110: Debian fzf package doesn't include shell integration scripts
+# Must run as root to write to /usr/share/doc/fzf/examples/
 RUN mkdir -p /usr/share/doc/fzf/examples && \
     wget -q -O /usr/share/doc/fzf/examples/key-bindings.zsh \
       https://raw.githubusercontent.com/junegunn/fzf/master/shell/key-bindings.zsh && \
     wget -q -O /usr/share/doc/fzf/examples/completion.zsh \
       https://raw.githubusercontent.com/junegunn/fzf/master/shell/completion.zsh
+
+# Switch to non-root user
+USER node
 
 # Install ZSH with Powerlevel10k (as non-root user)
 ARG ZSH_IN_DOCKER_VERSION=1.2.0

--- a/docs/examples/streamlit-sandbox-basic/.devcontainer/Dockerfile
+++ b/docs/examples/streamlit-sandbox-basic/.devcontainer/Dockerfile
@@ -72,16 +72,17 @@ RUN ARCH=$(dpkg --print-architecture) && \
 # Set working directory
 WORKDIR /workspace
 
-# Switch to non-root user
-USER node
-
 # Download fzf shell integration files (not included in Debian package)
 # Issue #110: Debian fzf package doesn't include shell integration scripts
+# Must run as root to write to /usr/share/doc/fzf/examples/
 RUN mkdir -p /usr/share/doc/fzf/examples && \
     wget -q -O /usr/share/doc/fzf/examples/key-bindings.zsh \
       https://raw.githubusercontent.com/junegunn/fzf/master/shell/key-bindings.zsh && \
     wget -q -O /usr/share/doc/fzf/examples/completion.zsh \
       https://raw.githubusercontent.com/junegunn/fzf/master/shell/completion.zsh
+
+# Switch to non-root user
+USER node
 
 # Install ZSH with Powerlevel10k (as non-root user)
 ARG ZSH_IN_DOCKER_VERSION=1.2.0

--- a/skills/_shared/templates/base.dockerfile
+++ b/skills/_shared/templates/base.dockerfile
@@ -149,14 +149,9 @@ RUN if [ "$ENABLE_FIREWALL" = "true" ]; then \
     echo "Empty domain allowlist created (YOLO mode)"; \
   fi
 
-USER node
-
-# NPM global config
-ENV NPM_CONFIG_PREFIX=/usr/local/share/npm-global
-ENV PATH=$PATH:/usr/local/share/npm-global/bin
-
 # Download fzf shell integration files (not included in Debian package)
 # Issue #110: Debian fzf package doesn't include shell integration scripts
+# Must run as root to write to /usr/share/doc/fzf/examples/
 RUN if [ "$INSTALL_SHELL_EXTRAS" = "true" ]; then \
     mkdir -p /usr/share/doc/fzf/examples && \
     wget -q -O /usr/share/doc/fzf/examples/key-bindings.zsh \
@@ -164,6 +159,12 @@ RUN if [ "$INSTALL_SHELL_EXTRAS" = "true" ]; then \
     wget -q -O /usr/share/doc/fzf/examples/completion.zsh \
       https://raw.githubusercontent.com/junegunn/fzf/master/shell/completion.zsh; \
   fi
+
+USER node
+
+# NPM global config
+ENV NPM_CONFIG_PREFIX=/usr/local/share/npm-global
+ENV PATH=$PATH:/usr/local/share/npm-global/bin
 
 # ZSH with Powerlevel10k - conditional on INSTALL_SHELL_EXTRAS
 ARG ZSH_IN_DOCKER_VERSION=1.2.0


### PR DESCRIPTION
## Summary

- Fixes permission denied error when Docker build tries to create `/usr/share/doc/fzf/examples/`
- Moves fzf download block to run as root before `USER node` directive
- Adds missing fzf download block to test-live Dockerfile
- Updates comments to explain why root permissions are required

## Problem

Docker builds were failing with:
```
/usr/share/doc/fzf/examples/key-bindings.zsh: Permission denied
```

Runtime errors also occurred in zsh:
```
no such file or directory: /usr/share/doc/fzf/examples/key-bindings.zsh
```

## Root Cause

The fzf download RUN command executed after `USER node`, but tried to write to `/usr/share/doc/fzf/examples/` - a root-owned system directory that the `node` user cannot write to.

## Solution

Move the fzf download block before the `USER node` directive so it runs with root permissions.

## Files Modified

- `skills/_shared/templates/base.dockerfile` - Template (source of truth)
- `.devcontainer/Dockerfile` - Main dev container
- `docs/examples/demo-app-sandbox-basic/.devcontainer/Dockerfile`
- `docs/examples/demo-app-sandbox-advanced/.devcontainer/Dockerfile`
- `docs/examples/streamlit-sandbox-basic/.devcontainer/Dockerfile`
- `.internal/tests/skill-validation/test-live/.devcontainer/Dockerfile` - Added missing block

## Test plan

- [ ] Rebuild Docker containers and verify no permission errors
- [ ] Verify fzf files exist: `ls -la /usr/share/doc/fzf/examples/`
- [ ] Verify ZSH starts without errors: `zsh -c 'echo OK'`
- [ ] Verify fzf integration works (Ctrl+R for history search)

🤖 Generated with [Claude Code](https://claude.com/claude-code)