### PR TITLE
fix: add missing setup-frontend.sh copy to both commands

### DIFF
--- a/commands/quickstart.md
+++ b/commands/quickstart.md
@@ -995,6 +995,7 @@ fi
 
 # Copy credential setup script
 cp "$TEMPLATES/setup-claude-credentials.sh" .devcontainer/
+cp "$TEMPLATES/setup-frontend.sh" .devcontainer/
 
 # Copy data files
 cp "$TEMPLATES/data/allowable-domains.json" data/
@@ -1275,6 +1276,7 @@ if [ "$NEEDS_FIREWALL" = "Yes" ]; then
   echo "  .devcontainer/init-firewall.sh";
 fi
 echo "  .devcontainer/setup-claude-credentials.sh"
+echo "  .devcontainer/setup-frontend.sh"
 echo "  docker-compose.yml"
 echo "  data/allowable-domains.json"
 echo "  .env.example"

--- a/commands/yolo-vibe-maxxing.md
+++ b/commands/yolo-vibe-maxxing.md
@@ -82,6 +82,7 @@ cp "$TEMPLATES/base.dockerfile" .devcontainer/Dockerfile
 cp "$TEMPLATES/devcontainer.json" .devcontainer/
 cp "$TEMPLATES/docker-compose.yml" ./
 cp "$TEMPLATES/setup-claude-credentials.sh" .devcontainer/
+cp "$TEMPLATES/setup-frontend.sh" .devcontainer/
 
 # Generate no-op firewall script (YOLO mode)
 cat > .devcontainer/init-firewall.sh << 'EOF'
@@ -123,6 +124,7 @@ echo "Files created:"
 echo "  .devcontainer/Dockerfile"
 echo "  .devcontainer/devcontainer.json"
 echo "  .devcontainer/setup-claude-credentials.sh"
+echo "  .devcontainer/setup-frontend.sh"
 echo "  docker-compose.yml"
 echo ""
 echo "Next: Open in VS Code → 'Reopen in Container'"


### PR DESCRIPTION
## Summary

Fixes missing `setup-frontend.sh` script error that caused DevContainer `postCreateCommand` to fail.

**Error:** 
```
/bin/sh: 1: .devcontainer/setup-frontend.sh: not found
postCreateCommand failed with exit code 127
```

**Root Cause:** Both `quickstart` and `yolo-vibe-maxxing` commands copy `setup-claude-credentials.sh` but were missing the copy operation for `setup-frontend.sh`, despite the devcontainer.json template referencing it in `postCreateCommand`.

## Changes

### Both Commands
- Added: `cp "$TEMPLATES/setup-frontend.sh" .devcontainer/`
- Updated output messaging to list `setup-frontend.sh` in "Files created"

### Files Modified
1. `/workspace/commands/yolo-vibe-maxxing.md` - Added copy command (line 85) and output (line 127)
2. `/workspace/commands/quickstart.md` - Added copy command (line 998) and output (line 1279)

## Why This Script Matters

The `setup-frontend.sh` script (37 lines) handles Windows→Linux npm platform detection:
- Detects Windows-specific node_modules (esbuild for win32)
- Reinstalls dependencies for Linux when running in WSL2/Docker
- Safe to always copy - handles its own no-op case when not needed

## Test Plan

- [x] Verified template file exists at `/workspace/skills/_shared/templates/setup-frontend.sh`
- [x] Confirmed script handles no-op case (exits gracefully if no node_modules)
- [ ] Test `yolo-vibe-maxxing` command - verify script is copied and postCreateCommand succeeds
- [ ] Test `quickstart` command - verify script is copied and postCreateCommand succeeds
- [ ] Test on Windows host with existing node_modules - verify platform detection works

## Related

This completes the fix chain:
1. PR #125 - Fixed unreplaced port placeholders in yolo-vibe-maxxing
2. This PR - Fixes missing setup-frontend.sh in both commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)