### PR TITLE
fix: add Go download domains and fix FIREWALL_MODE handling

### DIFF
--- a/commands/quickstart.md
+++ b/commands/quickstart.md
@@ -904,6 +904,37 @@ if [ "$NEEDS_FIREWALL" = "Yes" ]; then
     esac;
   done;
 
+  # Add language-specific package manager domains based on SELECTED_PARTIALS
+  for partial in "${SELECTED_PARTIALS[@]}"; do
+    case "$partial" in
+      "go")
+        echo "Adding Go domains for selected language...";
+        FIREWALL_DOMAINS+=$(jq -r '.categories.package_managers.sub_categories.go.domains[]' "$DOMAINS_JSON" | sed 's/^/  "/;s/$/"/');
+        FIREWALL_DOMAINS+="\n";
+        ;;
+      "rust")
+        echo "Adding Rust domains for selected language...";
+        FIREWALL_DOMAINS+=$(jq -r '.categories.package_managers.sub_categories.rust.domains[]' "$DOMAINS_JSON" | sed 's/^/  "/;s/$/"/');
+        FIREWALL_DOMAINS+="\n";
+        ;;
+      "ruby")
+        echo "Adding Ruby domains for selected language...";
+        FIREWALL_DOMAINS+=$(jq -r '.categories.package_managers.sub_categories.ruby.domains[]' "$DOMAINS_JSON" | sed 's/^/  "/;s/$/"/');
+        FIREWALL_DOMAINS+="\n";
+        ;;
+      "java")
+        echo "Adding Maven/Java domains for selected language...";
+        FIREWALL_DOMAINS+=$(jq -r '.categories.package_managers.sub_categories.maven.domains[]' "$DOMAINS_JSON" | sed 's/^/  "/;s/$/"/');
+        FIREWALL_DOMAINS+="\n";
+        ;;
+      "php")
+        echo "Adding PHP domains for selected language...";
+        FIREWALL_DOMAINS+=$(jq -r '.categories.package_managers.sub_categories.php.domains[]' "$DOMAINS_JSON" | sed 's/^/  "/;s/$/"/');
+        FIREWALL_DOMAINS+="\n";
+        ;;
+    esac;
+  done;
+
   # Add Anthropic services (always required)
   ANTHROPIC_DOMAINS=$(jq -r '.categories.anthropic_services.domains[]' "$DOMAINS_JSON" | sed 's/^/  "/;s/$/"/');
 

--- a/skills/_shared/templates/data/allowable-domains.json
+++ b/skills/_shared/templates/data/allowable-domains.json
@@ -167,7 +167,7 @@
           ]
         },
         "go": {
-          "description": "Go modules",
+          "description": "Go modules and toolchain downloads",
           "domains": [
             "proxy.golang.org",
             "sum.golang.org",
@@ -175,7 +175,11 @@
             "golang.org",
             "www.golang.org",
             "goproxy.io",
-            "pkg.go.dev"
+            "pkg.go.dev",
+            "go.dev",
+            "www.go.dev",
+            "dl.google.com",
+            "storage.googleapis.com"
           ]
         },
         "maven": {

--- a/skills/_shared/templates/init-firewall.sh
+++ b/skills/_shared/templates/init-firewall.sh
@@ -25,8 +25,8 @@ IFS=$'\n\t'       # Stricter word splitting
 # CONFIGURATION
 # ----------------------------------------------------------------------------
 
-# Firewall mode is always strict for domain allowlist configuration
-FIREWALL_MODE="strict"
+# Firewall mode: use environment variable if set, default to strict
+FIREWALL_MODE="${FIREWALL_MODE:-strict}"
 
 # CUSTOMIZE: Add your project-specific domains to this array
 # These domains will be allowed in addition to the defaults below
@@ -91,6 +91,21 @@ ALLOWED_DOMAINS=(
   "pypi.python.org"
   "pypa.io"
   "www.pypa.io"
+  # ===END_CATEGORY===
+
+  # ===CATEGORY:package_managers_go===
+  # Go modules and toolchain downloads
+  "proxy.golang.org"
+  "sum.golang.org"
+  "index.golang.org"
+  "golang.org"
+  "www.golang.org"
+  "goproxy.io"
+  "pkg.go.dev"
+  "go.dev"
+  "www.go.dev"
+  "dl.google.com"
+  "storage.googleapis.com"
   # ===END_CATEGORY===
 
   # ===CATEGORY:linux_distributions===


### PR DESCRIPTION
## Summary

Fixes three critical firewall configuration issues that caused DevContainer build failures when using the Go feature.

## Root Causes Fixed

1. **Missing Go download domains** - `go.dev`, `dl.google.com`, and `storage.googleapis.com` were not in the allowable domains list, blocking Go toolchain downloads
2. **FIREWALL_MODE hardcoded** - Template ignored environment variable from devcontainer.json
3. **No language-to-domain mapping** - Selecting Go language didn't automatically add Go domains to firewall

## Changes

### 1. allowable-domains.json
- Added `go.dev`, `www.go.dev`, `dl.google.com`, `storage.googleapis.com` to Go subcategory
- Updated description to "Go modules and toolchain downloads"

### 2. init-firewall.sh
- Changed line 29 from `FIREWALL_MODE="strict"` to `FIREWALL_MODE="${FIREWALL_MODE:-strict}"`
- Added complete Go domains section to ALLOWED_DOMAINS array

### 3. quickstart.md
- Added automatic domain injection logic that checks SELECTED_PARTIALS
- Supports Go, Rust, Ruby, Java, PHP language-specific domains

## Testing

Before:
```
curl: (35) OpenSSL SSL_connect: SSL_ERROR_SYSCALL in connection to dl.google.com:443
ERROR: Feature "Go" failed to install!
```

After:
- Go feature downloads succeed
- FIREWALL_MODE environment variable is respected
- Language-specific domains automatically included

🤖 Generated with [Claude Code](https://claude.com/claude-code)