### PR TITLE
fix: add HTTP/2 workarounds and architecture support to language partials

### DIFF
--- a/skills/_shared/templates/partials/azure-cli.dockerfile
+++ b/skills/_shared/templates/partials/azure-cli.dockerfile
@@ -7,11 +7,11 @@
 
 USER root
 
-# Install Azure CLI
-RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
+# Install Azure CLI (use --http1.1 to avoid HTTP/2 stream errors)
+RUN curl --http1.1 -sL https://aka.ms/InstallAzureCLIDeb | bash
 
-# Install Azure Developer CLI (azd)
-RUN curl -fsSL https://aka.ms/install-azd.sh | bash
+# Install Azure Developer CLI (azd) (use --http1.1 to avoid HTTP/2 stream errors)
+RUN curl --http1.1 -fsSL https://aka.ms/install-azd.sh | bash
 
 # Install Bicep CLI
 RUN az bicep install

--- a/skills/_shared/templates/partials/go.dockerfile
+++ b/skills/_shared/templates/partials/go.dockerfile
@@ -7,11 +7,12 @@
 
 USER root
 
-# Install Go 1.22
-ARG GO_VERSION=1.22.10
-RUN wget "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" && \
-    tar -C /usr/local -xzf "go${GO_VERSION}.linux-amd64.tar.gz" && \
-    rm "go${GO_VERSION}.linux-amd64.tar.gz"
+# Install Go 1.24 (architecture-aware, using wget for HTTP/1.1)
+ARG GO_VERSION=1.24.10
+RUN ARCH=$(dpkg --print-architecture) && \
+    wget "https://go.dev/dl/go${GO_VERSION}.linux-${ARCH}.tar.gz" && \
+    tar -C /usr/local -xzf "go${GO_VERSION}.linux-${ARCH}.tar.gz" && \
+    rm "go${GO_VERSION}.linux-${ARCH}.tar.gz"
 
 # Go environment variables
 ENV GOROOT=/usr/local/go

--- a/skills/_shared/templates/partials/java.dockerfile
+++ b/skills/_shared/templates/partials/java.dockerfile
@@ -20,7 +20,11 @@ RUN wget "https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin
     mv "gradle-${GRADLE_VERSION}" /opt/gradle && \
     rm "gradle-${GRADLE_VERSION}-bin.zip"
 
-# Java and Gradle environment
+# Java and Gradle environment (architecture-aware)
+RUN ARCH=$(dpkg --print-architecture) && \
+    mkdir -p /etc/profile.d && \
+    echo "export JAVA_HOME=/usr/lib/jvm/java-21-openjdk-${ARCH}" > /etc/profile.d/java.sh && \
+    chmod +x /etc/profile.d/java.sh
 ENV JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64
 ENV GRADLE_HOME=/opt/gradle
 ENV PATH=$PATH:$GRADLE_HOME/bin

--- a/skills/_shared/templates/partials/php.dockerfile
+++ b/skills/_shared/templates/partials/php.dockerfile
@@ -32,8 +32,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     php8.3-mysql \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Install Composer
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+# Install Composer (use --http1.1 to avoid HTTP/2 stream errors)
+RUN curl --http1.1 -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
 # PHP configuration
 RUN mkdir -p /usr/local/etc/php/conf.d && \

--- a/skills/_shared/templates/partials/rust.dockerfile
+++ b/skills/_shared/templates/partials/rust.dockerfile
@@ -7,8 +7,8 @@
 
 USER node
 
-# Install Rust via rustup
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+# Install Rust via rustup (use --http1.1 to avoid HTTP/2 stream errors)
+RUN curl --http1.1 --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
 # Rust environment
 ENV PATH=/home/node/.cargo/bin:$PATH


### PR DESCRIPTION
## Summary
- Fix curl error 18 (HTTP/2 stream not closed cleanly) in language partials
- Add architecture detection for arm64/Apple Silicon support
- Auto-enable Docker Compose app profiles for containerized deployment testing

## Changes

### Language Partials - HTTP/2 Fixes
- **rust.dockerfile**: Add `--http1.1` flag to rustup installer curl command
- **php.dockerfile**: Add `--http1.1` flag to Composer installer curl command
- **azure-cli.dockerfile**: Add `--http1.1` flag to Azure CLI and azd installers

### Language Partials - Architecture Support
- **go.dockerfile**: Add `dpkg --print-architecture` for amd64/arm64 detection, update to Go 1.24.10
- **java.dockerfile**: Make JAVA_HOME architecture-aware via `/etc/profile.d/java.sh`

### Quickstart Command
- **Force Go partial mode**: Bypass unreliable Go feature that uses curl without HTTP/1.1 support
- **Auto-enable app profiles**: Remove question, automatically enable Docker Compose profiles when backend/frontend directories detected

## Test Plan
- [ ] Build DevContainer with Go on arm64 (Apple Silicon)
- [ ] Build DevContainer with Rust (verify no HTTP/2 errors)
- [ ] Build DevContainer with Java on arm64
- [ ] Build DevContainer with PHP (verify no HTTP/2 errors)
- [ ] Build DevContainer with Azure CLI (verify no HTTP/2 errors)
- [ ] Run quickstart with Go - verify partial mode is used
- [ ] Run quickstart with backend/frontend dirs - verify app profiles auto-enabled

## Impact
Fixes curl failures with CDNs like dl.google.com and aka.ms that can cause HTTP/2 stream errors on certain networks. Enables DevContainers to build successfully on both amd64 and arm64 architectures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)