### PR TITLE
fix: standardize database credentials and add PROJECT_NAME validation

### DIFF
--- a/agents/devcontainer-generator.md
+++ b/agents/devcontainer-generator.md
@@ -160,7 +160,22 @@ Use `sed` commands to replace placeholders with actual values:
 
 ```bash
 # Get project name (e.g., "demo-app" or detected from directory)
-PROJECT_NAME="$1"  # Passed as argument
+
+# Sanitize project name for Docker compatibility
+sanitize_project_name() {
+  local name="$1"
+  local sanitized
+  sanitized=$(echo "$name" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g')
+  sanitized=$(echo "$sanitized" | sed 's/^-*//;s/-*$//;s/--*/-/g')
+  [ -z "$sanitized" ] && sanitized="sandbox-app"
+  echo "$sanitized"
+}
+
+RAW_PROJECT_NAME="$1"  # Passed as argument
+PROJECT_NAME="$(sanitize_project_name "$RAW_PROJECT_NAME")"
+if [ "$PROJECT_NAME" != "$RAW_PROJECT_NAME" ]; then
+  echo "Note: Project name sanitized: '$RAW_PROJECT_NAME' -> '$PROJECT_NAME'"
+fi
 
 # Replace {{PROJECT_NAME}} in all files
 sed -i "s/{{PROJECT_NAME}}/$PROJECT_NAME/g" .devcontainer/devcontainer.json

--- a/commands/quickstart.md
+++ b/commands/quickstart.md
@@ -767,7 +767,22 @@ fi
 ## Step 10: Build Dockerfile
 
 ```bash
-PROJECT_NAME="$(basename $(pwd))"
+# Sanitize project name for Docker compatibility
+sanitize_project_name() {
+  local name="$1"
+  local sanitized
+  sanitized=$(echo "$name" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g')
+  sanitized=$(echo "$sanitized" | sed 's/^-*//;s/-*$//;s/--*/-/g')
+  [ -z "$sanitized" ] && sanitized="sandbox-app"
+  echo "$sanitized"
+}
+
+RAW_PROJECT_NAME="$(basename $(pwd))"
+PROJECT_NAME="$(sanitize_project_name "$RAW_PROJECT_NAME")"
+if [ "$PROJECT_NAME" != "$RAW_PROJECT_NAME" ]; then
+  echo "Note: Project name sanitized: '$RAW_PROJECT_NAME' -> '$PROJECT_NAME'"
+fi
+
 TEMPLATES="$PLUGIN_ROOT/skills/_shared/templates"
 PARTIALS="$TEMPLATES/partials"
 
@@ -1048,8 +1063,8 @@ REDIS_PORT=$REDIS_PORT
 # ----------------------------------------------------------------------------
 # Database Configuration
 # ----------------------------------------------------------------------------
-POSTGRES_DB=devdb
-POSTGRES_USER=devuser
+POSTGRES_DB=sandbox_dev
+POSTGRES_USER=sandbox_user
 POSTGRES_PASSWORD=devpassword
 
 # Database URLs (for application use)

--- a/commands/yolo-vibe-maxxing.md
+++ b/commands/yolo-vibe-maxxing.md
@@ -49,7 +49,20 @@ fi
 ### Step 2: Copy Templates and Process Placeholders
 
 ```bash
-PROJECT_NAME="$(basename $(pwd))"
+# Sanitize project name for Docker compatibility (yolo mode: auto-fix, no prompts)
+sanitize_project_name() {
+  local name="$1"
+  local sanitized
+  sanitized=$(echo "$name" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g')
+  sanitized=$(echo "$sanitized" | sed 's/^-*//;s/-*$//;s/--*/-/g')
+  [ -z "$sanitized" ] && sanitized="sandbox-app"
+  echo "$sanitized"
+}
+
+RAW_PROJECT_NAME="$(basename $(pwd))"
+PROJECT_NAME="$(sanitize_project_name "$RAW_PROJECT_NAME")"
+[ "$PROJECT_NAME" != "$RAW_PROJECT_NAME" ] && echo "Auto-sanitized: $RAW_PROJECT_NAME -> $PROJECT_NAME"
+
 TEMPLATES="$PLUGIN_ROOT/skills/_shared/templates"
 DATA="$PLUGIN_ROOT/skills/_shared/templates/data"
 

--- a/skills/_shared/templates/.env.example
+++ b/skills/_shared/templates/.env.example
@@ -20,8 +20,8 @@ REDIS_PORT=6379
 # ----------------------------------------------------------------------------
 # Database Configuration
 # ----------------------------------------------------------------------------
-POSTGRES_DB=devdb
-POSTGRES_USER=devuser
+POSTGRES_DB=sandbox_dev
+POSTGRES_USER=sandbox_user
 POSTGRES_PASSWORD=devpassword
 
 # Database URLs (for application use)

--- a/skills/_shared/templates/docker-compose-profiles.yml
+++ b/skills/_shared/templates/docker-compose-profiles.yml
@@ -50,15 +50,15 @@ services:
     container_name: {{PROJECT_NAME}}-postgres
     restart: unless-stopped
     environment:
-      POSTGRES_DB: ${POSTGRES_DB:-devdb}
-      POSTGRES_USER: ${POSTGRES_USER:-devuser}
+      POSTGRES_DB: ${POSTGRES_DB:-sandbox_dev}
+      POSTGRES_USER: ${POSTGRES_USER:-sandbox_user}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-devpassword}
     ports:
       - "${POSTGRES_PORT:-5432}:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-devuser}"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-sandbox_user}"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -120,11 +120,11 @@ services:
     restart: unless-stopped
     environment:
       # Database connection
-      DATABASE_URL: postgresql://${POSTGRES_USER:-devuser}:${POSTGRES_PASSWORD:-devpassword}@postgres:5432/${POSTGRES_DB:-devdb}
+      DATABASE_URL: postgresql://${POSTGRES_USER:-sandbox_user}:${POSTGRES_PASSWORD:-devpassword}@postgres:5432/${POSTGRES_DB:-sandbox_dev}
       POSTGRES_HOST: postgres
       POSTGRES_PORT: 5432
-      POSTGRES_DB: ${POSTGRES_DB:-devdb}
-      POSTGRES_USER: ${POSTGRES_USER:-devuser}
+      POSTGRES_DB: ${POSTGRES_DB:-sandbox_dev}
+      POSTGRES_USER: ${POSTGRES_USER:-sandbox_user}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-devpassword}
       # Redis connection
       REDIS_URL: redis://redis:6379/0

--- a/skills/_shared/templates/docker-compose.prebuilt.yml
+++ b/skills/_shared/templates/docker-compose.prebuilt.yml
@@ -35,15 +35,15 @@ services:
     container_name: {{PROJECT_NAME}}-postgres
     restart: unless-stopped
     environment:
-      POSTGRES_DB: ${POSTGRES_DB:-devdb}
-      POSTGRES_USER: ${POSTGRES_USER:-devuser}
+      POSTGRES_DB: ${POSTGRES_DB:-sandbox_dev}
+      POSTGRES_USER: ${POSTGRES_USER:-sandbox_user}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-devpassword}
     ports:
       - "${POSTGRES_PORT:-5432}:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-devuser}"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-sandbox_user}"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/skills/_shared/templates/docker-compose.volume.yml
+++ b/skills/_shared/templates/docker-compose.volume.yml
@@ -53,15 +53,15 @@ services:
     container_name: {{PROJECT_NAME}}-postgres
     restart: unless-stopped
     environment:
-      POSTGRES_DB: ${POSTGRES_DB:-devdb}
-      POSTGRES_USER: ${POSTGRES_USER:-devuser}
+      POSTGRES_DB: ${POSTGRES_DB:-sandbox_dev}
+      POSTGRES_USER: ${POSTGRES_USER:-sandbox_user}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-devpassword}
     ports:
       - "${POSTGRES_PORT:-5432}:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-devuser}"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-sandbox_user}"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/skills/_shared/templates/docker-compose.yml
+++ b/skills/_shared/templates/docker-compose.yml
@@ -42,15 +42,15 @@ services:
     container_name: {{PROJECT_NAME}}-postgres
     restart: unless-stopped
     environment:
-      POSTGRES_DB: ${POSTGRES_DB:-devdb}
-      POSTGRES_USER: ${POSTGRES_USER:-devuser}
+      POSTGRES_DB: ${POSTGRES_DB:-sandbox_dev}
+      POSTGRES_USER: ${POSTGRES_USER:-sandbox_user}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-devpassword}
     ports:
       - "${POSTGRES_PORT:-5432}:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-devuser}"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-sandbox_user}"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/skills/_shared/templates/init-volume.sh
+++ b/skills/_shared/templates/init-volume.sh
@@ -13,7 +13,23 @@
 set -e
 
 PROJECT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-PROJECT_NAME="$(basename "$PROJECT_DIR")"
+
+# Sanitize project name for Docker compatibility
+sanitize_project_name() {
+  local name="$1"
+  local sanitized
+  sanitized=$(echo "$name" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g')
+  sanitized=$(echo "$sanitized" | sed 's/^-*//;s/-*$//;s/--*/-/g')
+  [ -z "$sanitized" ] && sanitized="sandbox-app"
+  echo "$sanitized"
+}
+
+RAW_PROJECT_NAME="$(basename "$PROJECT_DIR")"
+PROJECT_NAME="$(sanitize_project_name "$RAW_PROJECT_NAME")"
+if [ "$PROJECT_NAME" != "$RAW_PROJECT_NAME" ]; then
+  echo "Note: Project name sanitized: '$RAW_PROJECT_NAME' -> '$PROJECT_NAME'"
+fi
+
 VOLUME_NAME="${PROJECT_NAME}-workspace-volume"
 
 echo "Initializing volume: $VOLUME_NAME"


### PR DESCRIPTION
- Align template defaults with variables.json source of truth
- Add sanitize_project_name() function for Docker compatibility
- Keep .devcontainer/ credentials separate (plugin dev isolation)

BUG 1: Database Credentials
- Updated 4 docker-compose templates to use sandbox_user/sandbox_dev
- Updated .env.example to match
- Updated quickstart.md generated credentials
- .devcontainer intentionally keeps sandboxxer_user (plugin dev)

BUG 2: PROJECT_NAME Validation
- Added sanitize_project_name() to quickstart.md
- Added to yolo-vibe-maxxing.md (auto-fix mode)
- Added to init-volume.sh
- Added to devcontainer-generator.md
- Handles: lowercase, special chars, empty names, Docker limits

Fixes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)