### PR TITLE
Fix #159: Improve quickstart template discovery and add Claude CLI verification

### DIFF
--- a/skills/_shared/templates/devcontainer.json
+++ b/skills/_shared/templates/devcontainer.json
@@ -67,7 +67,7 @@
 
   "initializeCommand": ["docker", "volume", "create", "{{PROJECT_NAME}}-workspace-volume"],
   "onCreateCommand": "rm -rf /workspace/.venv 2>/dev/null || true; if [ -d '/tmp/host-source' ] && [ -z \"$(ls -A /workspace 2>/dev/null)\" ]; then cp -r /tmp/host-source/. /workspace/; fi",
-  "postCreateCommand": ".devcontainer/setup-claude-credentials.sh && .devcontainer/setup-frontend.sh",
+  "postCreateCommand": "sudo chmod +x .devcontainer/*.sh 2>/dev/null || true; .devcontainer/setup-claude-credentials.sh && .devcontainer/setup-frontend.sh",
   "updateContentCommand": "echo '🧹 Cleaning stale .venv after rebuild...' && rm -rf /workspace/.venv 2>/dev/null || true",
   "postStartCommand": "sudo /usr/local/bin/init-firewall.sh && echo 'DevContainer ready!'",
   "postAttachCommand": "",
@@ -105,7 +105,7 @@
   },
 
   "remoteEnv": {
-    "PATH": "/usr/local/bin:${containerEnv:PATH}",
+    "PATH": "/home/node/.local/bin:/usr/local/bin:${containerEnv:PATH}",
     "FIREWALL_MODE": "permissive",
     // Inherit from host (if set):
     "ANTHROPIC_API_KEY": "${localEnv:ANTHROPIC_API_KEY}",


### PR DESCRIPTION
## Summary

Fixes #159 - Quickstart was silently using wrong/stale templates, resulting in generated devcontainers missing Claude CLI and uv.

## Root Cause

The quickstart command's template discovery logic had no debugging output and didn't validate that templates were actually found. When `CLAUDE_PLUGIN_ROOT` wasn't set or the plugin search failed, it could silently proceed with wrong templates or fail without clear error messages.

## Changes

### 1. Improved Template Discovery (Primary Fix)
**File:** `commands/quickstart.md` Step 9

- Added verbose output showing which discovery method is used
- Fixed `.claude-plugin/` subdirectory handling in plugin search
- Added validation that templates exist before proceeding
- Improved error messages with remediation steps

### 2. Added Copy Verification
**File:** `commands/quickstart.md` Step 10

- Verifies base.dockerfile was copied successfully
- Shows line count of copied file for transparency

### 3. Added Verification Output
**File:** `commands/quickstart.md` Step 13

- Explicitly lists "Claude CLI" and "uv" in stack summary
- Prevents user confusion about included tools

### 4. Fixed PATH Configuration
**File:** `skills/_shared/templates/devcontainer.json`

- Added `/home/node/.local/bin` to remoteEnv PATH
- Ensures consistency with Dockerfile ENV

### 5. Windows/WSL2 Permission Fix
**File:** `skills/_shared/templates/devcontainer.json`

- Added `sudo chmod +x .devcontainer/*.sh` to postCreateCommand
- Handles Windows hosts losing execute permissions on mounted scripts

## Testing

Users will now see clear output when running quickstart:
```
Searching for plugin templates...
  Using CLAUDE_PLUGIN_ROOT: /path/to/plugin
  Templates found at: /path/to/plugin/skills/_shared/templates/
  Copied base.dockerfile (290 lines)

Your Stack:
  Base: Python 3.12 + Node 20
  + Claude CLI (claude command)
  + uv (Python package manager)
```

## Notes

The templates always included Claude CLI and uv - this fix ensures they're actually used and clearly communicated to users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)