### PR TITLE
fix: add database parameter to PostgreSQL healthcheck in all templates

### DIFF
--- a/docs/examples/docker-compose.yml
+++ b/docs/examples/docker-compose.yml
@@ -37,7 +37,7 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-sandbox_user}"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-sandbox_user} -d ${POSTGRES_DB:-sandbox_dev}"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docs/features/TROUBLESHOOTING.md
+++ b/docs/features/TROUBLESHOOTING.md
@@ -610,7 +610,7 @@ docker inspect <container-name> | grep -A 20 Health
 Edit `docker-compose.yml`:
 ```yaml
 healthcheck:
-  test: ["CMD-SHELL", "pg_isready -U sandbox_user"]
+  test: ["CMD-SHELL", "pg_isready -U sandbox_user -d sandbox_dev"]
   interval: 10s
   timeout: 5s
   retries: 5
@@ -621,8 +621,8 @@ healthcheck:
 
 Ensure command matches service configuration:
 ```yaml
-# PostgreSQL - match username
-test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER}"]
+# PostgreSQL - match username and database
+test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
 
 # Redis - use correct auth
 test: ["CMD", "redis-cli", "--pass", "${REDIS_PASSWORD}", "ping"]

--- a/skills/_shared/templates/docker-compose-profiles.yml
+++ b/skills/_shared/templates/docker-compose-profiles.yml
@@ -58,7 +58,7 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-sandbox_user}"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-sandbox_user} -d ${POSTGRES_DB:-sandbox_dev}"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/skills/_shared/templates/docker-compose.prebuilt.yml
+++ b/skills/_shared/templates/docker-compose.prebuilt.yml
@@ -43,7 +43,7 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-sandbox_user}"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-sandbox_user} -d ${POSTGRES_DB:-sandbox_dev}"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/skills/_shared/templates/docker-compose.volume.yml
+++ b/skills/_shared/templates/docker-compose.volume.yml
@@ -61,7 +61,7 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-sandbox_user}"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-sandbox_user} -d ${POSTGRES_DB:-sandbox_dev}"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/skills/_shared/templates/docker-compose.yml
+++ b/skills/_shared/templates/docker-compose.yml
@@ -50,7 +50,7 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-sandbox_user}"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-sandbox_user} -d ${POSTGRES_DB:-sandbox_dev}"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## Problem
When using quickstart, the postgres container healthcheck fails with:
```
FATAL: database "sandbox_user" does not exist
```

## Root Cause
The `pg_isready` healthcheck command in template files was missing the `-d` flag for database name. Without it, PostgreSQL defaults to connecting to a database with the same name as the username (`sandbox_user`), but only `sandbox_dev` exists.

## Solution
Added `-d ${POSTGRES_DB:-sandbox_dev}` to all `pg_isready` healthcheck commands to explicitly specify the target database.

## Files Modified
- `skills/_shared/templates/docker-compose.yml`
- `skills/_shared/templates/docker-compose.prebuilt.yml`
- `skills/_shared/templates/docker-compose.volume.yml`
- `skills/_shared/templates/docker-compose-profiles.yml`
- `docs/examples/docker-compose.yml`
- `docs/features/TROUBLESHOOTING.md`

## Change
**From:**
```yaml
test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-sandbox_user}"]
```

**To:**
```yaml
test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-sandbox_user} -d ${POSTGRES_DB:-sandbox_dev}"]
```

## Impact
- All quickstart-generated projects will now have correct healthchecks
- PostgreSQL containers will properly report healthy status
- Eliminates confusing "database does not exist" errors in logs
- Documentation examples now show the correct pattern

## Test Plan
- [x] Fixed all 4 template files in `skills/_shared/templates/`
- [x] Updated documentation examples
- [x] Verified YAML syntax consistency
- [ ] Test with quickstart to generate new project
- [ ] Verify postgres healthcheck passes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)