### PR TITLE
Fix .env preservation bugs causing data loss

### DIFF
--- a/commands/yolo-vibe-maxxing.md
+++ b/commands/yolo-vibe-maxxing.md
@@ -155,19 +155,14 @@ merge_env_value() {
 if [ -f ".env.backup" ]; then
   echo "Preserving .env values..."
   preserved_count=0
-  while IFS='=' read -r key value; do
+  while IFS='=' read -r key value || [ -n "$key" ]; do
     [ -z "$key" ] && continue
     [[ "$key" =~ ^[[:space:]]*# ]] && continue
-    [ -z "$value" ] && continue
 
-    escaped_key=$(printf '%s' "$key" | sed 's/[.[\*^$()+?{|\\]/\\&/g')
-    existing_value=$(grep "^${escaped_key}=" .env 2>/dev/null | cut -d= -f2-)
-
-    if [ -z "$existing_value" ]; then
-      merge_env_value "$key" "$value" .env
-      preserved_count=$((preserved_count + 1))
-      echo "  Preserved: $key"
-    fi
+    # Always overlay backup values (user data wins over template defaults)
+    merge_env_value "$key" "$value" .env
+    preserved_count=$((preserved_count + 1))
+    echo "  Preserved: $key"
   done < .env.backup
   echo "  Preserved $preserved_count values"
   rm -f .env.backup


### PR DESCRIPTION
## Summary

- Fixed awk deduplication filter that skipped empty values like `EMPTY_VAR=`
- Added newline handling to preserve last line when file lacks trailing newline
- Changed preservation logic from conditional to unconditional overlay (user values always win)
- Moved preservation outside merge-choice block so it runs regardless of user choice
- Added standalone .env backup for quickstart when no devcontainer.json exists

## Test Plan

- [ ] Test empty value preservation: Create `.env` with `EMPTY_VAR=`, run quickstart/yolo, verify preserved
- [ ] Test no-trailing-newline: Create `.env` ending with `LAST_VAR=value` (no newline), verify preserved
- [ ] Test user override: Create `.env` with `APP_PORT=9999`, run command, verify not replaced by template default
- [ ] Test preservation without merge: Run quickstart, skip merge option, verify .env still preserved
- [ ] Test standalone backup: Run quickstart in dir with `.env` but no `.devcontainer/`, verify backup created

🤖 Generated with [Claude Code](https://claude.com/claude-code)