### PR TITLE
fix: correct .env preservation logic in quickstart

### DIFF
--- a/commands/quickstart.md
+++ b/commands/quickstart.md
@@ -1090,7 +1090,7 @@ for f in .devcontainer/devcontainer.json docker-compose.yml; do
 done
 
 # Start with existing .env if available, otherwise create fresh
-if [ "$FRESH_ENV" = "false" ] && [ -f ".devcontainer.backup/.env" ]; then
+if [ "$FRESH_ENV" != "true" ] && [ -f ".devcontainer.backup/.env" ]; then
   cp .devcontainer.backup/.env .env
   echo "Preserved existing .env file"
 


### PR DESCRIPTION
## Summary
- Fixed .env preservation bug where existing values were overwritten during `/quickstart` on existing projects
- Changed condition from `FRESH_ENV = "false"` to `FRESH_ENV != "true"` to handle unset variables correctly
- Verified that default behavior now preserves existing .env values and `--fresh-env` flag still works

## Root Cause
Variable `FRESH_ENV` doesn't persist across separate bash code blocks in `quickstart.md`. When unset, the old condition `[ "$FRESH_ENV" = "false" ]` evaluated to FALSE, causing fresh template generation instead of preservation.

## Solution
Changed to opt-in logic: `[ "$FRESH_ENV" != "true" ]` evaluates to TRUE when variable is unset, correctly preserving backups by default.

## Test Plan
- ✅ Verified unset `FRESH_ENV` now preserves existing `.env` values
- ✅ Verified `FRESH_ENV=true` (--fresh-env flag) still generates fresh template
- ✅ Compared old vs new behavior to confirm bug is fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)