### PR TITLE
Fix .env variable concatenation on missing trailing newline

### DIFF
--- a/commands/quickstart.md
+++ b/commands/quickstart.md
@@ -1098,6 +1098,8 @@ done
 # Start with existing .env if available, otherwise create fresh
 if [ ! -f ".devcontainer.backup/.fresh-env-requested" ] && [ -f ".devcontainer.backup/.env" ]; then
   cp .devcontainer.backup/.env .env
+  # Ensure trailing newline (prevents variable concatenation on append)
+  [ -n "$(tail -c 1 .env 2>/dev/null)" ] && echo "" >> .env
   echo "Preserved existing .env file"
 
   # Add missing template defaults (only keys that don't exist)
@@ -1111,6 +1113,8 @@ if [ ! -f ".devcontainer.backup/.fresh-env-requested" ] && [ -f ".devcontainer.b
 
     # Only add if key doesn't exist
     if ! grep -q "^${escaped_key}=" "$target_file" 2>/dev/null; then
+      # Ensure trailing newline before appending
+      [ -f "$target_file" ] && [ -n "$(tail -c 1 "$target_file" 2>/dev/null)" ] && echo "" >> "$target_file"
       printf '%s=%s\n' "$key" "$value" >> "$target_file"
       echo "  Added missing: $key"
     fi

--- a/commands/yolo-vibe-maxxing.md
+++ b/commands/yolo-vibe-maxxing.md
@@ -147,6 +147,8 @@ merge_env_value() {
       return 1
     fi
   else
+    # Ensure trailing newline before appending
+    [ -f "$target_file" ] && [ -n "$(tail -c 1 "$target_file" 2>/dev/null)" ] && echo "" >> "$target_file"
     printf '%s=%s\n' "$key" "$value" >> "$target_file"
   fi
 }


### PR DESCRIPTION
## Summary

Fixes a bug where environment variables get concatenated onto the last line when appending to `.env` files that lack trailing newlines.

**Before (bug):**
```
REDIS_PORT=POSTGRES_DB=sandbox_dev
```

**After (fixed):**
```
REDIS_PORT=
POSTGRES_DB=sandbox_dev
```

## Changes

- Added newline check after copying preserved `.env` backup (quickstart.md:1102)
- Added newline check in `add_missing_env_defaults` function before each append (quickstart.md:1117)
- Added newline check in `merge_env_value` function (yolo-vibe-maxxing.md:151)

The fix uses the idiom `[ -n "$(tail -c 1 file)" ]` to detect files missing trailing newlines and adds one before appending.

## Test Plan

- [x] Created test `.env` file without trailing newline
- [x] Verified newline detection works correctly
- [x] Verified variables append on separate lines after fix
- [x] Verified files with trailing newlines are not affected (no double newlines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)