### PR TITLE
refactor: eliminate footer metadata from all markdown files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -526,7 +526,3 @@ Update your usage:
 - Network isolation and security
 - Health checks for all services
 
----
-
-**Last Updated:** 2025-12-25
-**Version:** 4.6.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -221,24 +221,16 @@ Before submitting changes, please review the [`.internal/repo-keeper/ORGANIZATIO
 
 **Key guidelines:**
 
-1. **Version Footers**: Add version footers to all new .md files
-   ```markdown
-   ---
+1. **Inventory**: Update [`.internal/repo-keeper/INVENTORY.json`](.internal/repo-keeper/INVENTORY.json) when adding/removing files
 
-   **Last Updated:** YYYY-MM-DD
-   **Version:** X.Y.Z
-   ```
+2. **Cross-References**: Use relative paths for internal links (not absolute `/workspace/` paths)
 
-2. **Inventory**: Update [`.internal/repo-keeper/INVENTORY.json`](.internal/repo-keeper/INVENTORY.json) when adding/removing files
-
-3. **Cross-References**: Use relative paths for internal links (not absolute `/workspace/` paths)
-
-4. **Naming Conventions**:
+3. **Naming Conventions**:
    - Commands: `/sandboxxer:{action}`
    - Skills: `sandboxxer-{action}/SKILL.md`
    - Templates: `{component}.{ext}`
 
-5. **Validation**: Run these scripts before committing:
+4. **Validation**: Run these scripts before committing:
    ```bash
    # Check version consistency
    .internal/repo-keeper/scripts/check-version-sync.sh
@@ -252,7 +244,3 @@ Before submitting changes, please review the [`.internal/repo-keeper/ORGANIZATIO
 
 See the full [Organization Checklist](.internal/repo-keeper/ORGANIZATION_CHECKLIST.md) for complete guidelines.
 
----
-
-**Last Updated:** 2025-12-25
-**Version:** 4.6.0

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -409,7 +409,3 @@ The devcontainer sets minimal environment variables:
 - **Claude Code**: https://claude.ai/code
 - **Plugin Development**: Use `/sandboxxer:troubleshoot` for debugging
 
----
-
-**Last Updated:** 2025-12-25
-**Version:** 4.6.0

--- a/README.md
+++ b/README.md
@@ -838,7 +838,3 @@ For contributors and maintainers, see [`.internal/repo-keeper/`](.internal/repo-
 
 See [CHANGELOG.md](CHANGELOG.md) for complete version history.
 
----
-
-**Last Updated:** 2025-01-02
-**Version:** 4.6.0

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -222,7 +222,3 @@ For security-related questions that are not vulnerabilities:
 2. Use [GitHub Discussions](https://github.com/andrewcchoi/sandbox-maxxing/discussions) for public questions
 3. Open a regular GitHub issue for feature requests
 
----
-
-**Last Updated:** 2025-12-25
-**Version:** 4.6.0

--- a/agents/devcontainer-generator.md
+++ b/agents/devcontainer-generator.md
@@ -339,7 +339,3 @@ Example:
 - Composition is explicit (base + partials)
 - Placeholders are replaced with sed, not manual editing
 
----
-
-**Last Updated:** 2025-12-25
-**Version:** 4.6.0

--- a/agents/devcontainer-validator.md
+++ b/agents/devcontainer-validator.md
@@ -168,7 +168,3 @@ Action Required: Delete wrong files, verify DevContainer setup
 - Orange color indicates validation/checking task
 
 
----
-
-**Last Updated:** 2025-12-25
-**Version:** 4.6.0

--- a/commands/README.md
+++ b/commands/README.md
@@ -361,7 +361,3 @@ See [Contributing Guide](../CONTRIBUTING.md) for:
 - Documentation updates
 - Testing guidelines
 
----
-
-**Last Updated:** 2025-12-25
-**Version:** 4.6.0

--- a/commands/audit.md
+++ b/commands/audit.md
@@ -18,7 +18,3 @@ Perform comprehensive security review of:
 - Dotfiles repository and installation scripts
 - Environment variables and secrets handling
 
----
-
-**Last Updated:** 2025-12-25
-**Version:** 4.6.0

--- a/commands/deploy-to-azure.md
+++ b/commands/deploy-to-azure.md
@@ -590,7 +590,3 @@ azd down
 ```
 
 ---
-
-**Last Updated:** 2026-01-01
-**Version:** 4.6.0
-

--- a/commands/quickstart.md
+++ b/commands/quickstart.md
@@ -1482,7 +1482,3 @@ wsl --unregister docker-desktop-data
 
 Replace `YOUR-PROJECT` with your project name. This approach bypasses the host shell entirely and works on Windows, macOS, and Linux.
 
----
-
-**Last Updated:** 2025-12-25
-**Version:** 4.6.0

--- a/commands/repo-keeper.md
+++ b/commands/repo-keeper.md
@@ -123,7 +123,3 @@ Display:
 - Use `--full` before releases
 
 ---
-
-**Last Updated:** 2026-01-01
-**Version:** 4.6.0
-

--- a/commands/troubleshoot.md
+++ b/commands/troubleshoot.md
@@ -14,7 +14,3 @@ Focus on identifying and resolving:
 - Permission errors
 - VS Code DevContainer issues
 
----
-
-**Last Updated:** 2025-12-24
-**Version:** 4.6.0

--- a/commands/yolo-vibe-maxxing.md
+++ b/commands/yolo-vibe-maxxing.md
@@ -204,7 +204,3 @@ echo "=========================================="
 
 **Note:** If the user provided a project name argument, replace `"$(basename $(pwd))"` with that argument in the PROJECT_NAME assignment.
 
----
-
-**Last Updated:** 2025-12-24
-**Version:** 4.6.0

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -282,7 +282,3 @@ Skills can invoke each other for related tasks:
 - [Minimal Configuration](examples/demo-app-sandbox-basic/) - Minimal configuration result
 - [Domain Allowlist](examples/demo-app-sandbox-advanced/) - Domain allowlist result
 
----
-
-**Last Updated:** 2025-12-25
-**Version:** 4.6.0

--- a/docs/CODESPACES.md
+++ b/docs/CODESPACES.md
@@ -179,7 +179,3 @@ For the best experience with Claude Code, VS Code Desktop is recommended.
 - [Prebuilds](https://docs.github.com/en/codespaces/prebuilding-your-codespaces)
 - [Machine Types](https://docs.github.com/en/codespaces/customizing-your-codespace/changing-the-machine-type-for-your-codespace)
 
----
-
-**Last Updated:** 2025-12-25
-**Version:** 4.6.0

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -34,7 +34,3 @@ Before publishing plugin:
 - [ ] GitHub release created
 - [ ] Documentation deployed
 
----
-
-**Last Updated:** 2025-12-25
-**Version:** 4.6.0

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -280,7 +280,3 @@ For skill-specific issues:
 - Compare with working skills for patterns
 
 
----
-
-**Last Updated:** 2025-12-25
-**Version:** 4.6.0

--- a/docs/diagrams/README.md
+++ b/docs/diagrams/README.md
@@ -352,7 +352,3 @@ docs/diagrams/
 - [Skills README](../../skills/README.md) - Skill documentation
 - [Commands README](../../commands/README.md) - Command reference
 
----
-
-**Last Updated:** 2025-12-25
-**Version:** 4.6.0

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -384,7 +384,3 @@ sudo /usr/local/bin/init-firewall.sh
 
 This project was created with [Claude](https://claude.ai) using the [Superpowers](https://github.com/obra/superpowers) plugin.
 
----
-
-**Last Updated:** 2025-12-25
-**Version:** 4.6.0

--- a/docs/examples/demo-app-sandbox-advanced/README.md
+++ b/docs/examples/demo-app-sandbox-advanced/README.md
@@ -495,7 +495,3 @@ alembic init migrations
 
 MIT
 
----
-
-**Last Updated:** 2025-12-25
-**Version:** 4.6.0

--- a/docs/examples/demo-app-sandbox-basic/README.md
+++ b/docs/examples/demo-app-sandbox-basic/README.md
@@ -295,7 +295,3 @@ docker-compose down
 
 MIT
 
----
-
-**Last Updated:** 2025-12-25
-**Version:** 4.6.0

--- a/docs/examples/demo-app-sandbox-yolo/README.md
+++ b/docs/examples/demo-app-sandbox-yolo/README.md
@@ -781,7 +781,3 @@ MIT
 
 **Custom Configuration** - Production-ready development environments with comprehensive tooling and best practices.
 
----
-
-**Last Updated:** 2025-12-25
-**Version:** 4.6.0

--- a/docs/examples/demo-app-shared/README.md
+++ b/docs/examples/demo-app-shared/README.md
@@ -185,7 +185,3 @@ Each sandbox example adds its own DevContainer configuration while reusing this 
 - [Demo App Advanced](../demo-app-sandbox-advanced/README.md)
 - [Demo App YOLO](../demo-app-sandbox-yolo/README.md)
 
----
-
-**Last Updated:** 2026-01-02
-**Version:** 4.6.0

--- a/docs/examples/streamlit-sandbox-basic/README.md
+++ b/docs/examples/streamlit-sandbox-basic/README.md
@@ -163,7 +163,3 @@ For more help, see [../../features/TROUBLESHOOTING.md](../../features/TROUBLESHO
 
 This example was generated using the **sandboxxer** plugin for Claude Code. It demonstrates what a Minimal Configuration setup looks like - minimal configuration, sensible defaults, and fast time-to-productivity.
 
----
-
-**Last Updated:** 2025-12-25
-**Version:** 4.6.0

--- a/docs/examples/streamlit-shared/README.md
+++ b/docs/examples/streamlit-shared/README.md
@@ -57,7 +57,3 @@ Once both tests pass:
   - Custom Configuration: `examples/demo-app-sandbox-yolo/`
 - 📖 Read the development guide: `docs/DEVELOPMENT.md`
 
----
-
-**Last Updated:** 2025-12-25
-**Version:** 4.6.0

--- a/docs/features/AZURE-DEPLOYMENT.md
+++ b/docs/features/AZURE-DEPLOYMENT.md
@@ -653,7 +653,3 @@ After deploying to Azure:
 - **GitHub Issues:** Report issues with this plugin at the repository
 
 ---
-
-**Last Updated:** 2026-01-01
-**Version:** 4.6.0
-

--- a/docs/features/CUSTOMIZATION.md
+++ b/docs/features/CUSTOMIZATION.md
@@ -596,7 +596,3 @@ And update firewall for AI provider APIs.
 - Check [troubleshooting](TROUBLESHOOTING.md) for common issues
 - Browse [examples/](../examples/) for complete configuration examples
 
----
-
-**Last Updated:** 2025-12-25
-**Version:** 4.6.0

--- a/docs/features/EXTENSIONS.md
+++ b/docs/features/EXTENSIONS.md
@@ -98,7 +98,3 @@ Extensions are configured in `.devcontainer/devcontainer.json`:
 }
 ```
 
----
-
-**Last Updated:** 2025-12-25
-**Version:** 4.6.0

--- a/docs/features/MCP.md
+++ b/docs/features/MCP.md
@@ -67,7 +67,3 @@ Sensitive credentials use VS Code input variables:
 - [Docker Hub MCP](https://docs.docker.com/ai/mcp-catalog-and-toolkit/hub-mcp/)
 - [VS Code MCP Servers](https://code.visualstudio.com/docs/copilot/customization/mcp-servers)
 
----
-
-**Last Updated:** 2025-12-25
-**Version:** 4.6.0

--- a/docs/features/NPM_PLATFORM_FIX.md
+++ b/docs/features/NPM_PLATFORM_FIX.md
@@ -99,7 +99,3 @@ Future support planned for:
 - Runs once during container creation, not on every start
 
 ---
-
-**Last Updated:** 2026-01-01
-**Version:** 4.6.0
-

--- a/docs/features/OLLAMA_INTEGRATION.md
+++ b/docs/features/OLLAMA_INTEGRATION.md
@@ -252,7 +252,3 @@ Requires:
 - [Ollama API Reference](https://github.com/ollama/ollama/blob/main/docs/api.md)
 
 ---
-
-**Last Updated:** 2026-01-01
-**Version:** 4.6.0
-

--- a/docs/features/SECRETS.md
+++ b/docs/features/SECRETS.md
@@ -772,7 +772,3 @@ secrets:
 - `skills/_shared/templates/data/secrets.json` - Complete secrets catalog
 - `skills/_shared/templates/.env.template` - Environment templates with secret placeholders
 
----
-
-**Last Updated:** 2025-12-25
-**Version:** 4.6.0

--- a/docs/features/SECURITY-MODEL.md
+++ b/docs/features/SECURITY-MODEL.md
@@ -560,7 +560,3 @@ If you have security questions or discover vulnerabilities:
 2. **Security vulnerabilities**: Follow responsible disclosure (see SECURITY.md in repository root, if available)
 3. **Configuration help**: See [TROUBLESHOOTING.md](TROUBLESHOOTING.md) or `/sandboxxer:troubleshoot` command
 
----
-
-**Last Updated:** 2025-12-25
-**Version:** 4.6.0

--- a/docs/features/SETUP-OPTIONS.md
+++ b/docs/features/SETUP-OPTIONS.md
@@ -239,7 +239,3 @@ See the [docker-compose templates](../../skills/_shared/templates/) directory fo
 - [Security Model](SECURITY-MODEL.md) - Firewall architecture and domain management
 - [Troubleshooting](TROUBLESHOOTING.md) - Common issues and solutions
 
----
-
-**Last Updated:** 2025-12-25
-**Version:** 4.6.0

--- a/docs/features/TROUBLESHOOTING.md
+++ b/docs/features/TROUBLESHOOTING.md
@@ -1357,7 +1357,3 @@ If you're still stuck:
    - GitHub Discussions: Community support
    - Include: Container logs, error messages, devcontainer.json, docker-compose.yml
 
----
-
-**Last Updated:** 2025-12-25
-**Version:** 4.6.0

--- a/docs/features/VARIABLES.md
+++ b/docs/features/VARIABLES.md
@@ -602,7 +602,3 @@ CC_LANGSMITH_DEBUG=false
 - `skills/_shared/templates/data/variables.json` - Complete variable catalog
 - `skills/_shared/templates/.env.template` - Environment file templates per mode
 
----
-
-**Last Updated:** 2025-12-25
-**Version:** 4.6.0

--- a/docs/windows/README.md
+++ b/docs/windows/README.md
@@ -94,7 +94,3 @@ When adding Windows-specific documentation:
 **Platform**: Windows 10/11, Windows Server 2019+
 **Requirements**: Git for Windows, PowerShell 5.1+
 
----
-
-**Last Updated:** 2025-12-25
-**Version:** 4.6.0

--- a/docs/windows/polyglot-hooks.md
+++ b/docs/windows/polyglot-hooks.md
@@ -296,7 +296,3 @@ All three should work if the wrapper is correctly implemented!
 - **Polyglot programming**: https://en.wikipedia.org/wiki/Polyglot_(computing)
 
 ---
-
-**Last Updated:** 2025-12-25
-**Version:** 4.6.0
-**Adapted from**: superpowers plugin by Jesse Vincent (obra)

--- a/docs/windows/troubleshooting.md
+++ b/docs/windows/troubleshooting.md
@@ -366,7 +366,3 @@ If you're still stuck after trying these solutions:
    - Output of `echo %CLAUDE_PLUGIN_ROOT%`
 
 ---
-
-**Last Updated:** 2025-12-25
-**Version:** 4.6.0
-**Platform**: Windows 10/11

--- a/hooks/README-WINDOWS.md
+++ b/hooks/README-WINDOWS.md
@@ -121,7 +121,3 @@ This error comes from Claude Code trying to use `/bin/bash` before the hook runs
 This chain avoids the `/bin/bash` error completely.
 
 
----
-
-**Last Updated:** 2025-12-21
-**Version:** 4.6.0

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -82,7 +82,3 @@ See [README-WINDOWS.md](README-WINDOWS.md) for:
 - [LangSmith Documentation](https://docs.langchain.com/langsmith)
 - [README-WINDOWS.md](README-WINDOWS.md) - Windows setup
 
----
-
-**Last Updated:** 2026-01-02
-**Version:** 4.6.0

--- a/skills/README.md
+++ b/skills/README.md
@@ -351,7 +351,3 @@ When reporting skill-related issues, include:
 - Relevant logs (Docker, VS Code, Claude)
 - Steps to reproduce
 
----
-
-**Last Updated:** 2025-12-25
-**Version:** 4.6.0

--- a/skills/_shared/templates/README.md
+++ b/skills/_shared/templates/README.md
@@ -148,7 +148,3 @@ DATA="$TEMPLATES/data"
 - [Data Directory README](data/README.md) - Detailed documentation of reference catalogs
 - [SETUP-OPTIONS.md](../../../docs/features/SETUP-OPTIONS.md) - Command comparison and setup workflows
 
----
-
-**Last Updated:** 2025-12-25
-**Version:** 4.6.0

--- a/skills/_shared/templates/data/README.md
+++ b/skills/_shared/templates/data/README.md
@@ -234,7 +234,3 @@ For questions about data file structure or usage, see:
 - Plugin documentation: `../docs/ARCHITECTURE.md`
 - Mode guide: `../docs/SETUP-OPTIONS.md`
 
----
-
-**Last Updated:** 2026-01-01
-**Version:** 4.6.0

--- a/skills/sandboxxer-audit/SKILL.md
+++ b/skills/sandboxxer-audit/SKILL.md
@@ -469,7 +469,3 @@ Assistant: I'll audit your firewall configuration.
 
 The skill reviews firewall mode, allowed domains, and provides guidance on adding necessary domains while maintaining security.
 
----
-
-**Last Updated:** 2025-12-25
-**Version:** 4.6.0

--- a/skills/sandboxxer-troubleshoot/SKILL.md
+++ b/skills/sandboxxer-troubleshoot/SKILL.md
@@ -260,7 +260,3 @@ Assistant: This sounds like a firewall configuration issue. Let me troubleshoot.
 
 The skill checks firewall mode, reviews allowed domains list, tests connectivity to specific domain, and provides guidance on adding OpenAI domains to allowlist.
 
----
-
-**Last Updated:** 2025-12-24
-**Version:** 4.6.0


### PR DESCRIPTION
## Summary
- Removed redundant Last Updated and Version footers from 47 markdown files
- CHANGELOG.md now serves as authoritative release date source
- Eliminates per-file maintenance of duplicate metadata

## Changes
- ✅ Removed footer pattern (`---`, `**Last Updated:**`, `**Version:**`) from all markdown files
- ✅ Updated CONTRIBUTING.md to remove footer instructions for contributors
- ✅ Preserved `last_updated` field in 8 JSON data files (these are updated independently)
- ✅ Verified CHANGELOG.md format remains intact as single source of truth

## Verification
```bash
# No footer metadata remaining in markdown files
grep "**Last Updated:**" **/*.md  # 0 matches
grep "**Version:**" **/*.md        # 0 matches

# JSON data files preserved
jq '.metadata.last_updated' skills/_shared/templates/data/*.json  # ✓ present

# CHANGELOG.md format confirmed
grep "^\[4\.6\.0\]" CHANGELOG.md  # ✓ [4.6.0] - 2025-12-25
```

## Result
Zero per-file footer maintenance going forward. Release dates tracked in CHANGELOG.md only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)