### PR TITLE
fix(hooks): quote path in PreToolUse hook for Windows compatibility

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd docker-safety-hook.sh",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" docker-safety-hook.sh",
             "timeout": 5000
           }
         ]


### PR DESCRIPTION
## Summary
- Add escaped quotes around `${CLAUDE_PLUGIN_ROOT}` path in PreToolUse hook to handle paths containing spaces on Windows (e.g., `C:\Program Files\...`)

## Changes
- Updated `hooks/hooks.json` line 9 to wrap the path in escaped quotes
- Pattern matches documentation in `docs/windows/polyglot-hooks.md` and the superpowers plugin

## Test plan
- [x] Validated JSON syntax with `jq`
- [x] Confirmed git diff shows only the quoting change
- [ ] Manual testing on Windows with spaces in path (if available)

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)