### PR TITLE
Change Claude Code installation from npm to native installer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -157,7 +157,7 @@ RUN uv init --name workspace-env && \
       requests
 
 # Install Claude Code
-RUN curl -fsSL https://claude.ai/install.sh | sh
+RUN curl -fsSL https://claude.ai/install.sh | bash
 RUN npm install -g \
   typescript \
   ts-node \

--- a/docs/examples/demo-app-sandbox-advanced/.devcontainer/Dockerfile
+++ b/docs/examples/demo-app-sandbox-advanced/.devcontainer/Dockerfile
@@ -57,7 +57,7 @@ ENV UV_COMPILE_BYTECODE=1 \
     PIP_NO_CACHE_DIR=1
 
 # Install Claude Code CLI
-RUN curl -fsSL https://claude.ai/install.sh | sh
+RUN curl -fsSL https://claude.ai/install.sh | bash
 
 # Install Mermaid CLI (Diagram Generation)
 RUN npm install -g @mermaid-js/mermaid-cli

--- a/docs/examples/demo-app-sandbox-basic/.devcontainer/Dockerfile
+++ b/docs/examples/demo-app-sandbox-basic/.devcontainer/Dockerfile
@@ -57,7 +57,7 @@ ENV UV_COMPILE_BYTECODE=1 \
     PIP_NO_CACHE_DIR=1
 
 # Install Claude Code CLI
-RUN curl -fsSL https://claude.ai/install.sh | sh
+RUN curl -fsSL https://claude.ai/install.sh | bash
 
 # Install Mermaid CLI (Diagram Generation)
 RUN npm install -g @mermaid-js/mermaid-cli

--- a/docs/examples/streamlit-sandbox-basic/.devcontainer/Dockerfile
+++ b/docs/examples/streamlit-sandbox-basic/.devcontainer/Dockerfile
@@ -57,7 +57,7 @@ ENV UV_COMPILE_BYTECODE=1 \
     PIP_NO_CACHE_DIR=1
 
 # Install Claude Code CLI
-RUN curl -fsSL https://claude.ai/install.sh | sh
+RUN curl -fsSL https://claude.ai/install.sh | bash
 
 # Install Mermaid CLI (Diagram Generation)
 RUN npm install -g @mermaid-js/mermaid-cli

--- a/docs/features/TROUBLESHOOTING.md
+++ b/docs/features/TROUBLESHOOTING.md
@@ -51,7 +51,7 @@ Claude Code is installed in the container filesystem, which is recreated on rebu
 Reinstall Claude Code after each container rebuild:
 
 ```bash
-curl -fsSL https://claude.ai/install.sh | sh
+curl -fsSL https://claude.ai/install.sh | bash
 ```
 
 **Automation Option:**
@@ -59,7 +59,7 @@ Add to `.devcontainer/postCreateCommand` or `postStartCommand`:
 
 ```json
 {
-  "postCreateCommand": "curl -fsSL https://claude.ai/install.sh | sh"
+  "postCreateCommand": "curl -fsSL https://claude.ai/install.sh | bash"
 }
 ```
 
@@ -755,7 +755,7 @@ npm install --dry-run
 **Verify the fix:**
 ```bash
 # Should succeed without errors
-curl -fsSL https://claude.ai/install.sh | sh
+curl -fsSL https://claude.ai/install.sh | bash
 ```
 
 ---

--- a/skills/_shared/templates/base.dockerfile
+++ b/skills/_shared/templates/base.dockerfile
@@ -233,7 +233,7 @@ RUN if [ "$INSTALL_DEV_TOOLS" = "true" ]; then \
   fi
 
 # Install Claude Code (always required)
-RUN curl -fsSL https://claude.ai/install.sh | sh
+RUN curl -fsSL https://claude.ai/install.sh | bash
 
 # Core Node tools (always installed - package managers)
 RUN npm install -g yarn pnpm


### PR DESCRIPTION
## Summary
- Replaces `npm install -g @anthropic-ai/claude-code` with native installer `curl -fsSL https://claude.ai/install.sh | sh`
- Removes unused `CLAUDE_CODE_VERSION` build arguments
- Updates installation verification in troubleshooting docs

## Benefits
- Native binary performance
- Better system integration
- Official installation method
- Reduced Node.js dependency overhead

## Files Changed
- `.devcontainer/Dockerfile`
- `skills/_shared/templates/base.dockerfile`
- `docs/examples/demo-app-sandbox-basic/.devcontainer/Dockerfile`
- `docs/examples/demo-app-sandbox-advanced/.devcontainer/Dockerfile`
- `docs/examples/streamlit-sandbox-basic/.devcontainer/Dockerfile`
- `docs/features/TROUBLESHOOTING.md`

## Test Plan
- [ ] Verify Dockerfile syntax is valid
- [ ] Test container build to confirm Claude installs correctly
- [ ] Verify native installer works across all example Dockerfiles

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)