### PR TITLE
Add openssh-client to devcontainer base packages

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -17,6 +17,7 @@ ENV TZ="$TZ"
 RUN apt-get update && apt-get install -y --no-install-recommends \
   # Core utilities
   git vim nano less procps sudo unzip wget curl ca-certificates gnupg gnupg2 \
+  openssh-client \
   # JSON processing and manual pages
   jq man-db uuid-runtime \
   # Shell and CLI enhancements

--- a/docs/examples/demo-app-sandbox-advanced/.devcontainer/Dockerfile
+++ b/docs/examples/demo-app-sandbox-advanced/.devcontainer/Dockerfile
@@ -17,6 +17,7 @@ FROM python:3.12-slim-bookworm
 RUN apt-get update && apt-get install -y --no-install-recommends \
     # Core utilities
     git vim nano less procps sudo unzip wget curl ca-certificates gnupg gnupg2 \
+    openssh-client \
     # JSON processing and manual pages
     jq man-db \
     # Shell and CLI enhancements

--- a/docs/examples/demo-app-sandbox-basic/.devcontainer/Dockerfile
+++ b/docs/examples/demo-app-sandbox-basic/.devcontainer/Dockerfile
@@ -17,6 +17,7 @@ FROM python:3.12-slim-bookworm
 RUN apt-get update && apt-get install -y --no-install-recommends \
     # Core utilities
     git vim nano less procps sudo unzip wget curl ca-certificates gnupg gnupg2 \
+    openssh-client \
     # JSON processing and manual pages
     jq man-db \
     # Shell and CLI enhancements

--- a/docs/examples/demo-app-sandbox-yolo/.devcontainer/Dockerfile
+++ b/docs/examples/demo-app-sandbox-yolo/.devcontainer/Dockerfile
@@ -38,6 +38,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ipset \
     # SSL certificates
     ca-certificates \
+    openssh-client \
     gnupg \
     # Process and system tools
     procps \

--- a/docs/examples/streamlit-sandbox-basic/.devcontainer/Dockerfile
+++ b/docs/examples/streamlit-sandbox-basic/.devcontainer/Dockerfile
@@ -17,6 +17,7 @@ FROM python:3.12-slim-bookworm
 RUN apt-get update && apt-get install -y --no-install-recommends \
     # Core utilities
     git vim nano less procps sudo unzip wget curl ca-certificates gnupg gnupg2 \
+    openssh-client \
     # JSON processing and manual pages
     jq man-db \
     # Shell and CLI enhancements


### PR DESCRIPTION
## Summary
- Add `openssh-client` package to all devcontainer Dockerfiles
- Enables SSH-based workflows (Git over SSH, key generation, remote access)

## Changes
Updated 5 Dockerfiles to include `openssh-client` in base package installations:
- `.devcontainer/Dockerfile`
- `docs/examples/demo-app-sandbox-basic/.devcontainer/Dockerfile`
- `docs/examples/demo-app-sandbox-advanced/.devcontainer/Dockerfile`
- `docs/examples/streamlit-sandbox-basic/.devcontainer/Dockerfile`
- `docs/examples/demo-app-sandbox-yolo/.devcontainer/Dockerfile`

## Test plan
- [ ] Rebuild devcontainer and verify `ssh` command is available
- [ ] Test `ssh -V` to confirm OpenSSH client version
- [ ] Verify SSH key generation works with `ssh-keygen`

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)