### PR TITLE
feat: add openssh-client to base.dockerfile template

### DIFF
--- a/skills/_shared/templates/base.dockerfile
+++ b/skills/_shared/templates/base.dockerfile
@@ -66,6 +66,7 @@ ENV TZ="$TZ"
 RUN apt-get update && apt-get install -y --no-install-recommends \
   # Core utilities
   git vim nano less procps sudo unzip wget curl ca-certificates gnupg gnupg2 \
+  openssh-client \
   # JSON processing and manual pages
   jq man-db uuid-runtime \
   # Shell and CLI enhancements


### PR DESCRIPTION
Add openssh-client to the shared base.dockerfile template used by both /sandboxxer:yolo-vibe-maxxing and /sandboxxer:quickstart commands.

This ensures devcontainers generated by these commands include SSH client support (ssh, ssh-keygen, etc.) without requiring users to manually add it.

Closes #200