### PR TITLE
feat: suppress npm migration message in devcontainers

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sandboxxer",
-  "version": "4.6.0",
+  "version": "4.7.0",
   "description": "Interactive assistant for creating VS Code DevContainer configurations with Docker Compose support. Build multi-stack environments by selecting multiple languages (Go, Rust, Ruby, PHP, C++, PostgreSQL tools) with optional network firewall.",
   "author": {
     "name": "shadow developer"

--- a/.devcontainer/setup-claude-credentials.sh
+++ b/.devcontainer/setup-claude-credentials.sh
@@ -36,7 +36,7 @@ echo "================================================================"
 # 0. Cross-Platform Git Configuration
 # ============================================================================
 echo ""
-echo "[0/9] Configuring git for cross-platform development..."
+echo "[0/10] Configuring git for cross-platform development..."
 
 # Prevent file mode (755/644) differences between Linux/Windows
 git config --global core.filemode false
@@ -62,7 +62,7 @@ mkdir -p "$CLAUDE_DIR/mcp"
 # 2. Core Configuration Files
 # ============================================================================
 echo ""
-echo "[1/9] Copying core configuration files..."
+echo "[1/10] Copying core configuration files..."
 
 for config_file in ".credentials.json" "settings.json" "settings.local.json" "projects.json" ".mcp.json"; do
     if [ -f "$HOST_CLAUDE/$config_file" ]; then
@@ -76,7 +76,7 @@ done
 # 3. Hooks Directory
 # ============================================================================
 echo ""
-echo "[2/9] Syncing hooks directory..."
+echo "[2/10] Syncing hooks directory..."
 
 if [ -d "$HOST_CLAUDE/hooks" ] && [ "$(ls -A "$HOST_CLAUDE/hooks" 2>/dev/null)" ]; then
     cp -r "$HOST_CLAUDE/hooks/"* "$CLAUDE_DIR/hooks/" 2>/dev/null || true
@@ -106,7 +106,7 @@ fi
 # 4. State Directory
 # ============================================================================
 echo ""
-echo "[3/9] Syncing state directory..."
+echo "[3/10] Syncing state directory..."
 
 if [ -d "$HOST_CLAUDE/state" ] && [ "$(ls -A "$HOST_CLAUDE/state" 2>/dev/null)" ]; then
     cp -r "$HOST_CLAUDE/state/"* "$CLAUDE_DIR/state/" 2>/dev/null || true
@@ -129,7 +129,7 @@ fi
 # 5. Plugins Directory
 # ============================================================================
 echo ""
-echo "[4/9] Syncing plugins directory..."
+echo "[4/10] Syncing plugins directory..."
 echo "Skip..."
 
 # if [ -d "$HOST_CLAUDE/plugins" ] && [ "$(ls -A "$HOST_CLAUDE/plugins" 2>/dev/null)" ]; then
@@ -153,7 +153,7 @@ echo "Skip..."
 # 6. MCP Configuration
 # ============================================================================
 echo ""
-echo "[5/9] Syncing MCP configuration..."
+echo "[5/10] Syncing MCP configuration..."
 
 # Copy .mcp.json if exists (already handled above, but check for mcp/ dir)
 if [ -d "$HOST_CLAUDE/mcp" ]; then
@@ -172,7 +172,7 @@ fi
 # 7. Environment Variables (Optional)
 # ============================================================================
 echo ""
-echo "[6/9] Loading environment variables..."
+echo "[6/10] Loading environment variables..."
 
 if [ -f "$HOST_ENV/.env.claude" ]; then
     # Source environment variables
@@ -194,7 +194,7 @@ fi
 # 8. GitHub CLI Authentication (Optional)
 # ============================================================================
 echo ""
-echo "[7/9] Setting up GitHub CLI authentication..."
+echo "[7/10] Setting up GitHub CLI authentication..."
 
 if [ -d "$HOST_GH" ]; then
     mkdir -p "$GH_CONFIG_DIR"
@@ -221,7 +221,7 @@ fi
 # 9. Copy Hooks for Linux Container (Optional)
 # ============================================================================
 echo ""
-echo "[8/9] Setting up hooks..."
+echo "[8/10] Setting up hooks..."
 
 HOOKS_SRC="/workspace/.devcontainer/defaults/hooks"
 HOOKS_DST="$CLAUDE_DIR/hooks"
@@ -246,10 +246,25 @@ else
 fi
 
 # ============================================================================
-# 10. Fix Permissions
+# 10. Mark Native Installation Complete
 # ============================================================================
 echo ""
-echo "[9/9] Setting permissions..."
+echo "[9/10] Marking native installation as complete..."
+
+# Run claude install to suppress migration notice
+# This is needed because copying host config makes Claude think it's a migration
+if command -v claude &> /dev/null; then
+    claude install 2>/dev/null || true
+    echo "  ✓ Native installation marked complete"
+else
+    echo "  ⚠ Claude CLI not found in PATH"
+fi
+
+# ============================================================================
+# 11. Fix Permissions
+# ============================================================================
+echo ""
+echo "[10/10] Setting permissions..."
 
 chown -R "$(id -u):$(id -g)" "$CLAUDE_DIR" 2>/dev/null || true
 chown -R "$(id -u):$(id -g)" "$GH_CONFIG_DIR" 2>/dev/null || true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sandboxxer Plugin
 
-![Version](https://img.shields.io/badge/version-4.6.0-blue)
+![Version](https://img.shields.io/badge/version-4.7.0-blue)
 ![Claude Code](https://img.shields.io/badge/claude--code-plugin-purple)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Platform](https://img.shields.io/badge/platform-Linux%20%7C%20macOS%20%7C%20Windows%20WSL2-lightgrey)


### PR DESCRIPTION
Add a new setup step that runs `claude install` after copying host credentials to mark the native installation as complete. This prevents the npm migration notice from appearing when starting Claude Code in a fresh devcontainer.

The migration message was triggered because:
- setup-claude-credentials.sh copies ~/.claude config from host machine
- Host config may contain metadata from prior npm-based installation
- Container has Claude installed via native installer (curl-based)
- Claude Code detects existing config + native binary = shows migration notice

Changes:
- Add Section 10 to setup-claude-credentials.sh: "Mark Native Installation Complete"
  - Runs `claude install` to suppress migration notice
  - Uses error suppression (2>/dev/null || true) to avoid script failure
  - Checks for claude CLI existence before running command
- Update all step counters from [x/9] to [x/10] throughout script
- Renumber permissions section from Section 10 to Section 11
- Bump plugin version from 4.6.0 to 4.7.0 in plugin.json and README.md

This ensures a clean user experience when launching Claude Code in devcontainers without the confusing migration message.