### PR TITLE
fix: correct Docker build context path for init-firewall.sh

### DIFF
--- a/skills/_shared/templates/base.dockerfile
+++ b/skills/_shared/templates/base.dockerfile
@@ -269,7 +269,7 @@ RUN if [ "$INSTALL_DEV_TOOLS" = "true" ]; then \
 
 # Firewall initialization script - conditional setup
 # File is copied by setup commands (quickstart or yolo-vibe-maxxing)
-COPY .devcontainer/init-firewall.s[h] /tmp/firewall/
+COPY init-firewall.s[h] /tmp/firewall/
 
 USER root
 RUN if [ "$ENABLE_FIREWALL" = "true" ]; then \


### PR DESCRIPTION
The COPY instruction referenced .devcontainer/init-firewall.sh, but the GitHub Actions workflow sets build context to ./skills/_shared/templates where the file exists directly as init-firewall.sh (not in a .devcontainer subdirectory).