### PR TITLE
fix: add required owner field to marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,6 +2,9 @@
   "name": "sandbox-maxxing",
   "version": "4.10.1",
   "description": "Local development marketplace for creating VS Code DevContainer configurations with Docker Compose support",
+  "owner": {
+    "name": "shadow developer"
+  },
   "author": {
     "name": "shadow developer",
     "email": "github-sandbox@shadowenvironment.com"


### PR DESCRIPTION
Adds the missing `owner` field to marketplace.json to comply with Claude Code CLI marketplace schema requirements. Without this field, `claude plugins add` fails with validation error: "Invalid input: expected object, received undefined"

The owner field is distinct from the author field and is required by the marketplace schema for proper plugin registration and installation.