### PR TITLE
fix: add SSH sudoers permissions to base.dockerfile template

### DIFF
--- a/skills/_shared/templates/base.dockerfile
+++ b/skills/_shared/templates/base.dockerfile
@@ -287,6 +287,9 @@ RUN if [ "$ENABLE_FIREWALL" = "true" ]; then \
   # Sudoers entry needed for both modes (postStartCommand compatibility)
   echo "node ALL=(root) NOPASSWD: SETENV: /usr/local/bin/init-firewall.sh" > /etc/sudoers.d/node-firewall && \
   chmod 0440 /etc/sudoers.d/node-firewall && \
+  # Allow node user to set up SSH directory with proper permissions
+  echo "node ALL=(root) NOPASSWD: /bin/mkdir -p /home/node/.ssh, /bin/chmod 700 /home/node/.ssh, /bin/chown -R node\\:node /home/node/.ssh" > /etc/sudoers.d/node-ssh && \
+  chmod 0440 /etc/sudoers.d/node-ssh && \
   rm -rf /tmp/firewall
 USER node
 


### PR DESCRIPTION
Fixes password prompt in yolo-vibe-maxxing --portless when setting up SSH keys during container build. Grants passwordless sudo for SSH directory operations (mkdir, chmod, chown) matching the pattern in local Dockerfile.