### PR TITLE
feat: convert anonymous .venv volume to named py312-uv-venv volume

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "sandbox-maxxing",
-  "version": "4.10.1",
+  "version": "4.10.2",
   "description": "Local development marketplace for creating VS Code DevContainer configurations with Docker Compose support",
   "owner": {
     "name": "shadow developer"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sandboxxer",
-  "version": "4.10.1",
+  "version": "4.10.2",
   "description": "Interactive assistant for creating VS Code DevContainer configurations with Docker Compose support. Base stack includes Python 3.12 + Node 20, with optional languages (Go, Rust, Ruby, PHP, C++) and network firewall.",
   "author": {
     "name": "shadow developer",

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -15,8 +15,8 @@ services:
     working_dir: /workspace
     volumes:
       - ..:/workspace:cached
-      # Issue #108: Anonymous volume - isolates .venv from bind mount
-      - /workspace/.venv
+      # Issue #108: Named volume - isolates .venv from bind mount
+      - py312-uv-venv:/workspace/.venv
       # Host Claude config (read-only)
       - ~/.claude:/tmp/host-claude:ro
       # Optional: environment variables sync
@@ -116,6 +116,8 @@ networks:
     driver: bridge
 
 volumes:
+  py312-uv-venv:                           # Python 3.12 + uv virtual environment (project-scoped)
+    driver: local
   command-history:                         # Bash history (project-scoped)
     driver: local
   shared-claude-data:                      # Shared Claude config across all devcontainers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- Convert anonymous `.venv` volume to named volume `py312-uv-venv` for easier identification (#108)
+
 ## [4.10.1] - 2026-01-30
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sandboxxer Plugin
 
-![Version](https://img.shields.io/badge/version-4.10.1-blue)
+![Version](https://img.shields.io/badge/version-4.10.2-blue)
 ![Claude Code](https://img.shields.io/badge/claude--code-plugin-purple)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Platform](https://img.shields.io/badge/platform-Linux%20%7C%20macOS%20%7C%20Windows%20WSL2-lightgrey)

--- a/docs/examples/demo-app-sandbox-advanced/docker-compose.yml
+++ b/docs/examples/demo-app-sandbox-advanced/docker-compose.yml
@@ -11,7 +11,7 @@ services:
         NODE_VERSION: "20"
     volumes:
       - .:/workspace:cached
-      - /workspace/.venv  # Issue #108: Anonymous volume - isolates .venv from bind mount
+      - py312-uv-venv:/workspace/.venv  # Issue #108: Named volume - isolates .venv from bind mount
       - ~/.claude:/tmp/host-claude:ro  # Host Claude config (read-only)
     environment:
       # Database Configuration
@@ -88,6 +88,8 @@ services:
     restart: unless-stopped
 
 volumes:
+  py312-uv-venv:                           # Python 3.12 + uv virtual environment (project-scoped)
+    driver: local
   postgres-data:
     driver: local
   redis-data:

--- a/docs/examples/demo-app-sandbox-basic/docker-compose.yml
+++ b/docs/examples/demo-app-sandbox-basic/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       dockerfile: .devcontainer/Dockerfile
     volumes:
       - .:/workspace:cached
-      - /workspace/.venv  # Issue #108: Anonymous volume - isolates .venv from bind mount
+      - py312-uv-venv:/workspace/.venv  # Issue #108: Named volume - isolates .venv from bind mount
       - ~/.claude:/tmp/host-claude:ro  # Host Claude config (read-only)
     environment:
       - DATABASE_URL=${DATABASE_URL:-postgresql://${POSTGRES_USER:-sandbox_user}:${POSTGRES_PASSWORD:-devpassword}@postgres:5432/${POSTGRES_DB:-sandbox_dev}}
@@ -51,6 +51,8 @@ services:
       - demo-basic-network
 
 volumes:
+  py312-uv-venv:                           # Python 3.12 + uv virtual environment (project-scoped)
+    driver: local
   postgres-data:
 
 networks:

--- a/docs/examples/demo-app-sandbox-yolo/docker-compose.yml
+++ b/docs/examples/demo-app-sandbox-yolo/docker-compose.yml
@@ -24,8 +24,8 @@ services:
     volumes:
       # Workspace volume with optimal caching
       - .:/workspace:cached
-      # Issue #108: Anonymous volume - isolates .venv from bind mount
-      - /workspace/.venv
+      # Issue #108: Named volume - isolates .venv from bind mount
+      - py312-uv-venv:/workspace/.venv
       # Host Claude config (read-only)
       - ~/.claude:/tmp/host-claude:ro
       # Named volumes for better performance
@@ -272,6 +272,8 @@ services:
 # Volumes (Named volumes for better performance and persistence)
 # ==============================================================================
 volumes:
+  py312-uv-venv:                           # Python 3.12 + uv virtual environment (project-scoped)
+    driver: local
   postgres-data:
     driver: local
     driver_opts:

--- a/docs/examples/streamlit-sandbox-basic/docker-compose.yml
+++ b/docs/examples/streamlit-sandbox-basic/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       dockerfile: .devcontainer/Dockerfile
     volumes:
       - .:/workspace:cached
-      - /workspace/.venv  # Issue #108: Anonymous volume - isolates .venv from bind mount
+      - py312-uv-venv:/workspace/.venv  # Issue #108: Named volume - isolates .venv from bind mount
       - ~/.claude:/tmp/host-claude:ro  # Host Claude config (read-only)
     environment:
       - DATABASE_URL=${DATABASE_URL:-postgresql://${POSTGRES_USER:-sandbox_user}:${POSTGRES_PASSWORD:-devpassword}@postgres:5432/${POSTGRES_DB:-sandbox_dev}}
@@ -55,6 +55,8 @@ services:
       - streamlit-sandbox-network
 
 volumes:
+  py312-uv-venv:                           # Python 3.12 + uv virtual environment (project-scoped)
+    driver: local
   postgres-data:
 
 networks:

--- a/skills/_shared/templates/docker-compose-profiles.yml
+++ b/skills/_shared/templates/docker-compose-profiles.yml
@@ -53,7 +53,7 @@ services:
       - NET_RAW
     volumes:
       - .:/workspace:cached
-      - /workspace/.venv                           # Issue #108: Anonymous volume - isolates .venv from bind mount
+      - py312-uv-venv:/workspace/.venv             # Issue #108: Named volume - isolates .venv from bind mount
       # NOTE: Host bind mounts require these paths to exist on the host system
       # Create them manually if needed: mkdir -p ~/.claude ~/.config/claude-env ~/.config/gh
       - ~/.claude:/tmp/host-claude:ro              # Issue #30: Claude config
@@ -233,6 +233,8 @@ volumes:
   redis-data:
     driver: local
   # Development tooling persistence
+  py312-uv-venv:                           # Python 3.12 + uv virtual environment (project-scoped)
+    driver: local
   command-history:                         # Bash history (project-scoped, not shared)
     driver: local
   shared-claude-data:                      # Shared Claude config across all devcontainers

--- a/skills/_shared/templates/docker-compose.portless.yml
+++ b/skills/_shared/templates/docker-compose.portless.yml
@@ -42,7 +42,7 @@ services:
       - NET_RAW
     volumes:
       - .:/workspace:cached
-      - /workspace/.venv                           # Issue #108: Anonymous volume - isolates .venv from bind mount
+      - py312-uv-venv:/workspace/.venv             # Issue #108: Named volume - isolates .venv from bind mount
       # NOTE: Host bind mounts require these paths to exist on the host system
       # Create them manually if needed: mkdir -p ~/.claude ~/.config/claude-env ~/.config/gh
       - ~/.claude:/tmp/host-claude:ro              # Issue #30: Claude config
@@ -117,6 +117,8 @@ volumes:
   redis-data:
     driver: local
   # Development tooling persistence
+  py312-uv-venv:                           # Python 3.12 + uv virtual environment (project-scoped)
+    driver: local
   command-history:                         # Bash history (project-scoped, not shared)
     driver: local
   shared-claude-data:                      # Shared Claude config across all devcontainers

--- a/skills/_shared/templates/docker-compose.prebuilt.yml
+++ b/skills/_shared/templates/docker-compose.prebuilt.yml
@@ -37,7 +37,7 @@ services:
       - NET_RAW
     volumes:
       - .:/workspace:cached
-      - /workspace/.venv                           # Issue #108: Anonymous volume - isolates .venv from bind mount
+      - py312-uv-venv:/workspace/.venv             # Issue #108: Named volume - isolates .venv from bind mount
       # NOTE: Host bind mounts require these paths to exist on the host system
       # Create them manually if needed: mkdir -p ~/.claude ~/.config/claude-env ~/.config/gh
       - ~/.claude:/tmp/host-claude:ro              # Issue #30: Claude config
@@ -114,6 +114,8 @@ volumes:
   redis-data:
     driver: local
   # Development tooling persistence
+  py312-uv-venv:                           # Python 3.12 + uv virtual environment (project-scoped)
+    driver: local
   command-history:                         # Bash history (project-scoped, not shared)
     driver: local
   shared-claude-data:                      # Shared Claude config across all devcontainers

--- a/skills/_shared/templates/docker-compose.volume.yml
+++ b/skills/_shared/templates/docker-compose.volume.yml
@@ -56,7 +56,7 @@ services:
       - NET_RAW
     volumes:
       - {{PROJECT_NAME}}-workspace-volume:/workspace  # Named volume for better I/O performance
-      - /workspace/.venv                              # Issue #108: Anonymous volume - isolates .venv from workspace volume
+      - py312-uv-venv:/workspace/.venv                # Issue #108: Named volume - isolates .venv from workspace volume
       - ./.devcontainer:/workspace/.devcontainer:ro  # Scripts for postCreateCommand
       - .:/tmp/host-source:ro                    # Issue #91: For initial sync to volume
       # NOTE: Host bind mounts require these paths to exist on the host system
@@ -142,6 +142,8 @@ volumes:
   redis-data:
     driver: local
   # Development tooling persistence
+  py312-uv-venv:                           # Python 3.12 + uv virtual environment (project-scoped)
+    driver: local
   command-history:                         # Bash history (project-scoped, not shared)
     driver: local
   shared-claude-data:                      # Shared Claude config across all devcontainers

--- a/skills/_shared/templates/docker-compose.yml
+++ b/skills/_shared/templates/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       - NET_RAW
     volumes:
       - .:/workspace:cached
-      - /workspace/.venv                           # Issue #108: Anonymous volume - isolates .venv from bind mount
+      - py312-uv-venv:/workspace/.venv             # Issue #108: Named volume - isolates .venv from bind mount
       # NOTE: Host bind mounts require these paths to exist on the host system
       # Create them manually if needed: mkdir -p ~/.claude ~/.config/claude-env ~/.config/gh
       - ~/.claude:/tmp/host-claude:ro              # Issue #30: Claude config
@@ -127,6 +127,8 @@ volumes:
   redis-data:
     driver: local
   # Development tooling persistence
+  py312-uv-venv:                           # Python 3.12 + uv virtual environment (project-scoped)
+    driver: local
   command-history:                         # Bash history (project-scoped, not shared)
     driver: local
   shared-claude-data:                      # Shared Claude config across all devcontainers


### PR DESCRIPTION
Replaced anonymous .venv volume with named volume `py312-uv-venv` across all docker-compose files for easier identification and management. The named volume clearly indicates Python 3.12 + uv availability.

Changes:
- Updated 10 docker-compose files (templates, examples, devcontainer)
- Added volume declarations in all affected files
- Updated comments to reference Issue #108
- Incremented version to 4.10.2 in plugin.json, marketplace.json, README.md
- Added CHANGELOG entry for Issue #108

Closes #108