### PR TITLE
chore: improve devcontainer and hooks configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
   "name": "sandboxxer-plugin",
   "dockerComposeFile": "docker-compose.yml",
   "service": "app",
-  "workspaceFolder": "/workspace",
+  "workspaceFolder": "/workspace/${localWorkspaceFolderBasename}",
   "remoteUser": "node",
 
   "customizations": {
@@ -33,7 +33,7 @@
     }
   },
   "postCreateCommand": ".devcontainer/setup-claude-credentials.sh",
-  "postStartCommand": "sudo /usr/local/bin/init-firewall.sh",
+  "postStartCommand": "git config --global --add safe.directory '*' && sudo /usr/local/bin/init-firewall.sh",
   "remoteEnv": {
     "PATH": "/usr/local/bin:${containerEnv:PATH}"
   }

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"${CLAUDE_PLUGIN_ROOT//\\\\//}/hooks/run-hook.cmd\" sync-knowledge.sh",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" sync-knowledge.sh",
             "timeout": 15000
           }
         ]
@@ -16,30 +16,30 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"${CLAUDE_PLUGIN_ROOT//\\\\//}/hooks/run-hook.cmd\" session-end-hook.sh",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" session-end-hook.sh",
             "timeout": 15000
           }
         ]
       }
     ],
-    "PreToolUse": [
+    "PreToolUse_DISABLED": [
       {
         "matcher": "Bash",
         "hooks": [
           {
             "type": "command",
-            "command": "\"${CLAUDE_PLUGIN_ROOT//\\\\//}/hooks/run-hook.cmd\" docker-safety-hook.sh",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" docker-safety-hook.sh",
             "timeout": 5000
           }
         ]
       }
     ],
-    "Stop": [
+    "Stop_DISABLED": [
       {
         "hooks": [
           {
             "type": "command",
-            "command": "\"${CLAUDE_PLUGIN_ROOT//\\\\//}/hooks/run-hook.cmd\" langsmith-hook.sh",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" langsmith-hook.sh",
             "timeout": 30000
           }
         ]


### PR DESCRIPTION
Devcontainer improvements:
- Update workspaceFolder to use ${localWorkspaceFolderBasename} variable for better support when working with multiple workspace folders
- Add git safe.directory global config in postStartCommand to prevent "dubious ownership" errors when Git detects repository ownership issues

Hooks configuration:
- Simplify hook command paths by removing Windows path normalization pattern (//\\\\// replacement) from CLAUDE_PLUGIN_ROOT variable usage
- Disable PreToolUse hook (docker-safety-hook.sh) by renaming to PreToolUse_DISABLED
- Disable Stop hook (langsmith-hook.sh) by renaming to Stop_DISABLED
- Maintain sync-knowledge.sh and session-end-hook.sh as active hooks

These changes improve compatibility and reduce potential issues with workspace mounting and Git repository access in containerized environments.