### PR TITLE
fix: correct matcher field format in hooks configuration

### DIFF
--- a/hooks/hooks.example.json
+++ b/hooks/hooks.example.json
@@ -24,9 +24,7 @@
     ],
     "PreToolUse": [
       {
-        "matcher": {
-          "tool_name": "Bash"
-        },
+        "matcher": "Bash",
         "hooks": [
           {
             "type": "command",

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -24,9 +24,7 @@
     ],
     "PreToolUse": [
       {
-        "matcher": {
-          "tool_name": "Bash"
-        },
+        "matcher": "Bash",
         "hooks": [
           {
             "type": "command",


### PR DESCRIPTION
Changed matcher from object format {"tool_name": "Bash"} to string format "Bash" in both hooks.json and hooks.example.json. The Claude Code CLI hook loader expects matcher to be a string (regex pattern) that matches against tool names, not an object.

This fixes the plugin loading error:
"Invalid input: expected string, received object"